### PR TITLE
iOS integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["theseriousadult <jack@gallabytes.com>, ivanschuetz <ivanhp978@gmail.
 edition = "2018"
 
 [lib]
-name = "mobcore"
+name = "tcn_client"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,20 @@ version = "0.1.0"
 authors = ["theseriousadult <jack@gallabytes.com>, ivanschuetz <ivanhp978@gmail.com>"]
 edition = "2018"
 
+[lib]
+name = "mobcore"
+crate-type = ["cdylib", "staticlib"]
+
 [dependencies]
 persy = "0.9"
 once_cell = "1.3.1"
 reqwest = { version = "0.10.2", features = ["blocking", "json"] }
+cbindgen = "0.9.0"
+serde_json = "1.0"
+serde = "1.0"
+# ios
+libc = "0.2"
+core-foundation = "0.6.2"
 
 [dependencies.tcn]
 git = "https://github.com/TCNCoalition/TCN.git"

--- a/scripts/ios/create_ios_universal.sh
+++ b/scripts/ios/create_ios_universal.sh
@@ -1,0 +1,15 @@
+# Requirements: 
+# 1. https://github.com/getditto/rust-bitcode
+# 2. libtool
+# See https://github.com/Co-Epi/app-backend-rust/wiki/Building-library-for-iOS
+
+cd ../..
+
+RUSTFLAGS="-Z embed-bitcode" cargo +ios-arm64 build --target aarch64-apple-ios --release --lib
+cargo build --target=x86_64-apple-ios
+
+libtool -static -o ./target/libtcn_client.a ./target/aarch64-apple-ios/release/libtcn_client.a ./target/x86_64-apple-ios/release/libtcn_client.a
+
+# Copy lib into iOS app
+# mv ./target/libtcn_client.a <path to iOS app's root dir>
+

--- a/scripts/ios/create_ios_universal.sh
+++ b/scripts/ios/create_ios_universal.sh
@@ -3,10 +3,8 @@
 # 2. libtool
 # See https://github.com/Co-Epi/app-backend-rust/wiki/Building-library-for-iOS
 
-cd ../..
-
 RUSTFLAGS="-Z embed-bitcode" cargo +ios-arm64 build --target aarch64-apple-ios --release --lib
-cargo build --target=x86_64-apple-ios
+cargo build --target=x86_64-apple-ios --release
 
 libtool -static -o ./target/libtcn_client.a ./target/aarch64-apple-ios/release/libtcn_client.a ./target/x86_64-apple-ios/release/libtcn_client.a
 

--- a/src/ios_interface.rs
+++ b/src/ios_interface.rs
@@ -1,0 +1,72 @@
+
+use std::os::raw::{c_char};
+use core_foundation::string::{CFString, CFStringRef};
+use core_foundation::base::TCFType;
+use serde_json::Value;
+
+use crate::networking;
+
+#[no_mangle]
+pub unsafe extern "C" fn get_reports(interval_number: u32, interval_length: u32) -> CFStringRef {
+    println!("RUST: fetching reports for interval_number: {}, interval_length {}", interval_number, interval_length);
+
+    let result = networking::get_reports(interval_number, interval_length);
+
+    println!("RUST: Api returned: {:?}", result);
+
+    let result_string = match result {
+      Ok(reports) => {
+        println!("Get reports success: {:?}", reports);
+        // TODO types / protocol to communicate with app. For now we could use strings (JSON).
+        let json_value: Value = reports.into();
+        // TODO (reqwest::Error { kind: Decode, source: Error("invalid type: integer `1`, expected a sequence", line: 1, column: 1) })
+        format!("{}", json_value)
+      },
+      Err(e) => format!("ERROR posting report: {}", e)
+    };
+
+    let cf_string = CFString::new(&result_string);
+    let cf_string_ref = cf_string.as_concrete_TypeRef();
+
+    ::std::mem::forget(cf_string);
+
+    return cf_string_ref;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn post_report(c_report: *const c_char) -> CFStringRef {
+  println!("RUST: posting report: {:?}", c_report);
+
+  // TODO don't unwrap, use and handle result, handle
+  let report = cstring_to_str(&c_report).unwrap();
+
+  let result = networking::post_report(report.to_owned());
+
+  let result_string = match result {
+    Ok(response) => {
+      println!("Post report success: {:?}", response);
+      "ok".to_owned()
+    },
+    Err(e) => format!("ERROR posting report: {}", e)
+  };
+
+  let cf_string = CFString::new(&result_string);
+  let cf_string_ref = cf_string.as_concrete_TypeRef();
+
+  ::std::mem::forget(cf_string);
+
+  return cf_string_ref;
+}
+
+// Convert C string to Rust string slice
+unsafe fn cstring_to_str<'a>(cstring: &'a *const c_char) -> Option<&str> {
+  if cstring.is_null() {
+      return None;
+  }
+
+  let raw = ::std::ffi::CStr::from_ptr(*cstring);
+  match raw.to_str() {
+      Ok(s) => Some(s),
+      Err(_) => None
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use tcn::Report;
 use std::collections::HashSet;
 
 mod networking;
+mod ios_interface;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type Res<T> = Result<T, Error>;

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,6 +1,6 @@
 use reqwest::{blocking::{Client, Response}, Error};
 
-static BASE_URL: &str = "https://18ye1iivg6.execute-api.us-west-1.amazonaws.com/v4";
+static BASE_URL: &str = "https://zmqh8rwdx4.execute-api.us-west-2.amazonaws.com/v4/0.4.0";
 
 pub fn get_reports(interval_number: u32, interval_length: u32) -> Result<Vec<String>, Error> {
   let url: &str = &format!("{}/tcnreport", BASE_URL);

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -2,21 +2,20 @@ use reqwest::{blocking::{Client, Response}, Error};
 
 static BASE_URL: &str = "https://18ye1iivg6.execute-api.us-west-1.amazonaws.com/v4";
 
-fn get_reports(interval_number: u32, interval_length: u32) -> Result<Vec<String>, Error> {
+pub fn get_reports(interval_number: u32, interval_length: u32) -> Result<Vec<String>, Error> {
   let url: &str = &format!("{}/tcnreport", BASE_URL);
 
   create_client().and_then(|client| 
       client.get(url)
           .header("Content-Type", "application/json")
           .query(&[("intervalNumber", interval_number)])
-          // TODO: Will be changed to seconds
-          .query(&[("intervalLengthMs", interval_length)])
+          .query(&[("intervalLength", interval_length)])
           .send()
           .and_then (|response| response.json::<Vec<String>>())
   )
 }
 
-fn post_report(report: &'static str) -> Result<Response, Error> {
+pub fn post_report(report: String) -> Result<Response, Error> {
   let url: &str = &format!("{}/tcnreport", BASE_URL);
 
   create_client().and_then(|client| 
@@ -24,6 +23,7 @@ fn post_report(report: &'static str) -> Result<Response, Error> {
           .header("Content-Type", "application/json")
           .body(report)
           .send()
+          // TODO: Map to Error if status isn't 20x
   )
 }
 
@@ -47,7 +47,7 @@ mod tests {
 
   #[test]
   fn post_report_is_ok() {
-    let res = post_report("rSqWpM3ZQm7hfQ3q2x2llnFHiNhyRrUQPKEtJ33VKQcwT7Ly6e4KGaj5ZzjWt0m4c0v5n/VH5HO9UXbPXvsQTgEAQQAALFVtMVdNbHBZU1hOSlJYaDJZek5OWjJJeVdXZFpXRUozV2xoU2NHUkhWVDA9jn0pZAeME6ZBRHJOlfIikyfS0Pjg6l0txhhz6hz4exTxv8ryA3/Z26OebSRwzRfRgLdWBfohaOwOcSaynKqVCg==");
+    let res = post_report("rSqWpM3ZQm7hfQ3q2x2llnFHiNhyRrUQPKEtJ33VKQcwT7Ly6e4KGaj5ZzjWt0m4c0v5n/VH5HO9UXbPXvsQTgEAQQAALFVtMVdNbHBZU1hOSlJYaDJZek5OWjJJeVdXZFpXRUozV2xoU2NHUkhWVDA9jn0pZAeME6ZBRHJOlfIikyfS0Pjg6l0txhhz6hz4exTxv8ryA3/Z26OebSRwzRfRgLdWBfohaOwOcSaynKqVCg==".to_owned());
     assert!(res.is_ok());
     assert_eq!(res.unwrap().status(), StatusCode::from_u16(200).unwrap());
   }

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,6 +1,7 @@
 use reqwest::{blocking::{Client, Response}, Error};
 
-static BASE_URL: &str = "https://zmqh8rwdx4.execute-api.us-west-2.amazonaws.com/v4/0.4.0";
+// static BASE_URL: &str = "https://zmqh8rwdx4.execute-api.us-west-2.amazonaws.com/v4/0.4.0";
+static BASE_URL: &str = "https://v1.api.coepi.org/tcnreport/v0.4.0";
 
 pub fn get_reports(interval_number: u32, interval_length: u32) -> Result<Vec<String>, Error> {
   let url: &str = &format!("{}/tcnreport", BASE_URL);


### PR DESCRIPTION
Currently exposed functions:
- get_reports
- post_report

To generate library:
- Install [rustup](https://rustup.rs/)
- Add targets (e.g. for simulator: `rustup target add x86_64-apple-ios`)
- Run in the root directory of this repo: `cargo lipo --release`

To use library in the iOS app:
- Copy `libtcn_client.a` file in `target > x86_64-apple-ios > release`
- Paste in iOS app's root dir. Ensure to have checked out [the Rust integration branch](https://github.com/Co-Epi/app-ios/tree/feature/rust-integration).

To change the interface:
- Aside from updating the library (`.a` file), update the headers in `mobileapp-ios.h` (which is in the iOS app).

Some of these steps can be automated in the future.

I tested both calls in a view controller. The api calls are performed and the app receives the results as strings. Logs from Rust also show up in Xcode's console.

I'm considering using for now only primitives and Strings to communicate with Rust, to simplify things. We could use a JSON protocol (similar to when communicating with a remote server). But maybe using structs/enums isn't difficult. I haven't tried yet.

For the PR, I moved the calls to `CoEpiApi` and wrapped in Single, as proof of concept. This doesn't correctly at the moment, as `develop` still uses the 0.1 api and Rust 0.4. I also haven't tested the (for now very primitive) JSON serialization.






