### PR TITLE
Share dependencies

### DIFF
--- a/src/composition_root.rs
+++ b/src/composition_root.rs
@@ -4,13 +4,13 @@ use crate::{reporting::{memo::{MemoMapperImpl}, symptom_inputs::{SymptomInputsSu
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 
-pub struct CompositionRoot<
+pub struct CompositionRoot<'a,
   PreferencesType: Preferences, TcnDaoType: TcnDao, TcnMatcherType: TcnMatcher, ApiType: TcnApi, 
   // TODO don't pass concrete type for MemoMapper / TcnKeys here?
   SymptomInputsSubmitterType: SymptomInputsSubmitter<MemoMapperImpl, TcnKeysImpl<PreferencesType>, ApiType>, 
 > {
   pub api: ApiType,
-  pub reports_updater: ReportsUpdater<PreferencesType, TcnDaoType, TcnMatcherType, ApiType>,
+  pub reports_updater: ReportsUpdater<'a, PreferencesType, TcnDaoType, TcnMatcherType, ApiType>,
   pub symptom_inputs_submitter: SymptomInputsSubmitterType
 }
 
@@ -22,12 +22,12 @@ pub static COMP_ROOT: Lazy<
 > = 
   Lazy::new(|| create_comp_root());
 
-fn create_comp_root() -> CompositionRoot<
+fn create_comp_root() -> CompositionRoot<'static, 
   PreferencesImpl, TcnDaoImpl, TcnMatcherImpl, TcnApiImpl, 
-  SymptomInputsSubmitterImpl<MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>
+  SymptomInputsSubmitterImpl<'static, MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>
 > {
   // FIXME pass the same instances / references
-  // let api = TcnApiImpl {};
+  let api = &TcnApiImpl {};
   // let preferences = PreferencesImpl { config: RwLock::new(confy::load("coepi").unwrap()) };
 
   CompositionRoot { 
@@ -36,14 +36,14 @@ fn create_comp_root() -> CompositionRoot<
       preferences: PreferencesImpl { config: RwLock::new(confy::load("coepi").unwrap()) },
       tcn_dao: TcnDaoImpl {},
       tcn_matcher: TcnMatcherImpl {},
-      api: TcnApiImpl {}
+      api
     },
     symptom_inputs_submitter: SymptomInputsSubmitterImpl { 
       memo_mapper: MemoMapperImpl {},  
       tcn_keys: TcnKeysImpl { 
         preferences: PreferencesImpl { config: RwLock::new(confy::load("coepi").unwrap()) }
       },
-      api: TcnApiImpl {}
+      api
     }
   }
 }

--- a/src/reporting/symptom_inputs.rs
+++ b/src/reporting/symptom_inputs.rs
@@ -86,19 +86,19 @@ pub trait SymptomInputsSubmitter<
   fn submit_inputs(&self, inputs: SymptomInputs) -> Result<(), ServicesError>;
 }
 
-pub struct SymptomInputsSubmitterImpl<
+pub struct SymptomInputsSubmitterImpl<'a,
   MemoMapperType: MemoMapper, TcnKeysType: TcnKeys, TcnApiType: TcnApi
 > {
   pub memo_mapper: MemoMapperType,
   pub tcn_keys: TcnKeysType,
-  pub api: TcnApiType,
+  pub api: &'a TcnApiType,
 }
 
-impl <
+impl <'a,
   MemoMapperType: MemoMapper, TcnKeysType: TcnKeys, TcnApiType: TcnApi
 > SymptomInputsSubmitter<
   MemoMapperType, TcnKeysType, TcnApiType
-> for SymptomInputsSubmitterImpl<
+> for SymptomInputsSubmitterImpl<'a,
   MemoMapperType, TcnKeysType, TcnApiType
 > {
 

--- a/src/reports_updater.rs
+++ b/src/reports_updater.rs
@@ -69,18 +69,18 @@ pub struct Alert {
   // TODO date: Note: Contact date (port from Android)
 }
 
-pub struct ReportsUpdater<
+pub struct ReportsUpdater<'a, 
   PreferencesType: Preferences, TcnDaoType: TcnDao, TcnMatcherType: TcnMatcher, ApiType: TcnApi
 > {
   pub preferences: PreferencesType, 
   pub tcn_dao: TcnDaoType, 
   pub tcn_matcher: TcnMatcherType, 
-  pub api: ApiType
+  pub api: &'a ApiType
 }
 
-impl<
+impl<'a, 
   PreferencesType: Preferences, TcnDaoType: TcnDao, TcnMatcherType: TcnMatcher, ApiType: TcnApi
-> ReportsUpdater<PreferencesType, TcnDaoType, TcnMatcherType, ApiType> {
+> ReportsUpdater<'a, PreferencesType, TcnDaoType, TcnMatcherType, ApiType> {
 
   pub fn fetch_new_reports(&self) -> Result<Vec<Alert>, ServicesError> {
     self.retrieve_and_match_new_reports().map(|signed_reports|

--- a/src/reports_updater.rs
+++ b/src/reports_updater.rs
@@ -1,7 +1,7 @@
 use crate::{networking::{TcnApi, NetworkingError}, reports_interval, DB_UNINIT, DB, byte_vec_to_16_byte_array, errors::{Error, ServicesError}, preferences::{PreferencesKey, Preferences}};
 use reports_interval::{ReportsInterval, UnixTime};
 use tcn::SignedReport;
-use std::{collections::HashSet, time::Instant};
+use std::{collections::HashSet, time::Instant, rc::Rc, sync::Arc};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -72,7 +72,7 @@ pub struct Alert {
 pub struct ReportsUpdater<'a, 
   PreferencesType: Preferences, TcnDaoType: TcnDao, TcnMatcherType: TcnMatcher, ApiType: TcnApi
 > {
-  pub preferences: PreferencesType, 
+  pub preferences: Arc<PreferencesType>, 
   pub tcn_dao: TcnDaoType, 
   pub tcn_matcher: TcnMatcherType, 
   pub api: &'a ApiType

--- a/src/tcn_ext/tcn_keys.rs
+++ b/src/tcn_ext/tcn_keys.rs
@@ -1,6 +1,6 @@
 use crate::preferences::Preferences;
 use tcn::{TemporaryContactKey, ReportAuthorizationKey, MemoType, SignedReport, Error};
-use std::{cmp, io::Cursor};
+use std::{cmp, io::Cursor, sync::Arc};
 use cmp::max;
 
 pub trait TcnKeys {
@@ -8,7 +8,7 @@ pub trait TcnKeys {
 }
 
 pub struct TcnKeysImpl<PreferencesType: Preferences> {
-  pub preferences: PreferencesType,
+  pub preferences: Arc<PreferencesType>,
 }
 
 impl <PreferencesType: Preferences> TcnKeys for TcnKeysImpl<PreferencesType> {


### PR DESCRIPTION
As far I understand, specifying the lifetime is more performant, but it makes the code a bit more complicated. For the preferences [it was not possible to use it](https://github.com/Co-Epi/app-backend-rust/pull/12#discussion_r429623237) either way, so using referencing counting.