### PR TITLE
Submit symptoms bridge improvements & fixes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,4 +33,17 @@ impl From<TcnError> for ServicesError {
   }
 }
 
+impl From<String> for ServicesError {
+  fn from(error: String) -> Self {
+    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, error)))
+  }
+}
+
+impl From<serde_json::Error> for ServicesError {
+  fn from(error: serde_json::Error) -> Self {
+    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, format!("{}", error))))
+  }
+}
+
+
 impl error::Error for ServicesError {}

--- a/src/ios/c_headers/coepicore.h
+++ b/src/ios/c_headers/coepicore.h
@@ -3,3 +3,4 @@
 CFStringRef fetch_new_reports();
 CFStringRef get_reports(int32_t interval_number, int32_t interval_length);
 CFStringRef post_report(const char *to);
+CFStringRef submit_symptoms(const char *to);

--- a/src/ios/c_headers/coepicore.h
+++ b/src/ios/c_headers/coepicore.h
@@ -3,4 +3,20 @@
 CFStringRef fetch_new_reports();
 CFStringRef get_reports(int32_t interval_number, int32_t interval_length);
 CFStringRef post_report(const char *to);
-CFStringRef submit_symptoms(const char *to);
+
+// Variant to send finished inputs as JSON. Not continuing this approach for now.
+// CFStringRef submit_symptoms_complete(const char *to);
+
+CFStringRef set_cough_type(const char *to);
+  
+CFStringRef set_cough_days(uint8_t is_set, uint32_t days);
+CFStringRef set_cough_status(const char *status);
+CFStringRef set_breathlessness_cause(const char *cause);
+CFStringRef set_fever_days(uint8_t is_set, uint32_t days);
+CFStringRef set_fever_taken_temperature_today(uint8_t is_set, uint8_t taken);
+CFStringRef set_fever_taken_temperature_spot(const char *to);
+CFStringRef set_fever_highest_temperature_taken(uint8_t is_set, float days);
+CFStringRef set_earliest_symptom_started_days_ago(uint8_t is_set, uint32_t days);
+
+CFStringRef submit_symptoms();
+CFStringRef clear();

--- a/src/ios/ios_interface.rs
+++ b/src/ios/ios_interface.rs
@@ -65,12 +65,16 @@ pub unsafe extern "C" fn get_reports(interval_number: u32, interval_length: u32)
 
 #[no_mangle]
 pub unsafe extern "C" fn submit_symptoms(c_report: *const c_char) -> CFStringRef {
-  println!("RUST: posting report: {:?}", c_report);
+  println!("RUST: submitting symptoms: {:?}", c_report);
 
   // TODO don't unwrap, use and handle result, handle
-  let report = cstring_to_str(&c_report).unwrap();
+  let symptoms_str = cstring_to_str(&c_report).unwrap();
 
-  let inputs: Result<SymptomInputs, serde_json::Error> = serde_json::from_str(report);
+  println!("RUST: submitting symptoms, string: {:?}", symptoms_str);
+
+  let inputs: Result<SymptomInputs, serde_json::Error> = serde_json::from_str(symptoms_str);
+
+  println!("RUST: symptoms deserialization result: {:?}", inputs);
 
   let lib_result: LibResult<()> = match inputs {
     Ok(inputs) => {

--- a/src/ios/ios_interface.rs
+++ b/src/ios/ios_interface.rs
@@ -4,7 +4,8 @@ use core_foundation::string::{CFString, CFStringRef};
 use core_foundation::base::TCFType;
 use serde::Serialize;
 
-use crate::{composition_root::COMP_ROOT, networking, reporting::symptom_inputs::{SymptomInputsSubmitter, SymptomInputs}, errors::ServicesError::{Networking, Error}};
+use crate::{composition_root::COMP_ROOT, networking, reporting::symptom_inputs::{SymptomInputsSubmitter, SymptomInputs}, errors::ServicesError::{Networking, Error, self}};
+use crate::reporting::symptom_inputs_manager::SymptomInputsProcessor;
 use networking::TcnApi;
 
 // Generic struct to return results to app
@@ -24,20 +25,7 @@ pub unsafe extern "C" fn fetch_new_reports() -> CFStringRef {
 
   println!("RUST: new reports: {:?}", result);
 
-  let lib_result = match result {
-    Ok(success) => LibResult { status: 200, data: Some(success), error_message: None },
-    // TODO better error identification, using HTTP status for everything is weird.
-    Err(e) => LibResult { status: 500, data: None, error_message: Some(e.to_string()) }
-  };
-
-  let lib_result_string = serde_json::to_string(&lib_result).unwrap();
-
-  let cf_string = CFString::new(&lib_result_string);
-  let cf_string_ref = cf_string.as_concrete_TypeRef();
-
-  ::std::mem::forget(cf_string);
-
-  return cf_string_ref;
+  return to_result_str(result);
 }
 
 #[no_mangle]
@@ -63,8 +51,25 @@ pub unsafe extern "C" fn get_reports(interval_number: u32, interval_length: u32)
     return cf_string_ref;
 }
 
+fn to_result_str<T: Serialize>(result: Result<T, ServicesError>) -> CFStringRef {
+  let lib_result = match result {
+    Ok(success) => LibResult { status: 200, data: Some(success), error_message: None },
+    // TODO better error identification, using HTTP status for everything is weird.
+    Err(e) => LibResult { status: 500, data: None, error_message: Some(e.to_string()) }
+  };
+
+  let lib_result_string = serde_json::to_string(&lib_result).unwrap();
+
+  let cf_string = CFString::new(&lib_result_string);
+  let cf_string_ref = cf_string.as_concrete_TypeRef();
+
+  ::std::mem::forget(cf_string);
+
+  return cf_string_ref;
+}
+
 #[no_mangle]
-pub unsafe extern "C" fn submit_symptoms(c_report: *const c_char) -> CFStringRef {
+pub unsafe extern "C" fn submit_symptoms_complete(c_report: *const c_char) -> CFStringRef {
   println!("RUST: submitting symptoms: {:?}", c_report);
 
   // TODO don't unwrap, use and handle result, handle
@@ -101,6 +106,84 @@ pub unsafe extern "C" fn submit_symptoms(c_report: *const c_char) -> CFStringRef
   ::std::mem::forget(cf_string);
 
   return cf_string_ref;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_cough_type(c_cough_type: *const c_char) -> CFStringRef {
+  println!("RUST: setting cough type: {:?}", c_cough_type);
+  // TODO don't unwrap, use and handle result, handle
+  let cough_type_str = cstring_to_str(&c_cough_type).unwrap();
+  let result = COMP_ROOT.symptom_inputs_processor.set_cough_type(cough_type_str);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_cough_days(c_is_set: u8, c_days: u32) -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.set_cough_days(c_is_set == 1, c_days);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_cough_status(c_status: *const c_char) -> CFStringRef {
+  println!("RUST: setting cough status: {:?}", c_status);
+  // TODO don't unwrap, use and handle result, handle
+  let status_str = cstring_to_str(&c_status).unwrap();
+  let result = COMP_ROOT.symptom_inputs_processor.set_cough_status(status_str);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_breathlessness_cause(c_cause: *const c_char) -> CFStringRef {
+  println!("RUST: setting breathlessness cause: {:?}", c_cause);
+    // TODO don't unwrap, use and handle result, handle
+  let cause_str = cstring_to_str(&c_cause).unwrap();
+  let result = COMP_ROOT.symptom_inputs_processor.set_breathlessness_cause(cause_str);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_fever_days(c_is_set: u8, c_days: u32) -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.set_fever_days(c_is_set == 1, c_days);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_fever_taken_temperature_today(c_is_set: u8, c_taken: u8) -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.set_fever_taken_temperature_today(c_is_set == 1, c_taken== 1);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_fever_taken_temperature_spot(c_cause: *const c_char) -> CFStringRef {
+  println!("RUST: setting temperature spot cause: {:?}", c_cause);
+      // TODO don't unwrap, use and handle result, handle
+  let spot_str = cstring_to_str(&c_cause).unwrap();
+  let result = COMP_ROOT.symptom_inputs_processor.set_fever_taken_temperature_spot(spot_str);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_fever_highest_temperature_taken(c_is_set: u8, c_temp: f32) -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.set_fever_highest_temperature_taken(c_is_set == 1, c_temp);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn set_earliest_symptom_started_days_ago(c_is_set: u8, c_days: u32) -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.set_earliest_symptom_started_days_ago(c_is_set == 1, c_days);
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn clear_symptom_inputs() -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.clear();
+  return to_result_str(result);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn submit_symptoms() -> CFStringRef {
+  let result = COMP_ROOT.symptom_inputs_processor.submit();
+  return to_result_str(result);
 }
 
 #[no_mangle]

--- a/src/is_it_working.rs
+++ b/src/is_it_working.rs
@@ -7,10 +7,7 @@
 use std::path::Path;
 use tcn::TemporaryContactNumber;
 use super::*;
-use std::{collections::HashSet, fs};
-use tcn::SignedReport;
-use base64::DecodeError;
-use reports_updater::{TcnMatcherImpl, TcnMatcher};
+use std::fs;
 
 #[test]
 fn inits_db() {

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -37,12 +37,16 @@ impl TcnApi for TcnApiImpl {
   }
 
   fn post_report(&self, report: String) -> Result<(), NetworkingError> {
+    println!("RUST posting report: {}", report);
+
     let url: &str = &format!("{}/tcnreport", BASE_URL);
     let client = Self::create_client()?;
     let response = client.post(url)
       .header("Content-Type", "application/json")
       .body(report)
       .send()?;
+
+    println!("RUST post report success: {:?}", response);
     Ok(response).map(|_| ())
   }
 }

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -27,7 +27,6 @@ pub trait Preferences {
   fn last_completed_reports_interval(&self, key: PreferencesKey) -> Option<ReportsInterval>;
   fn set_last_completed_reports_interval(&self, key: PreferencesKey, value: ReportsInterval);
 
-
   // TODO encrypted
   fn authorization_key(&self) -> Option<[u8; 32]>;
   fn set_autorization_key(&self, value: [u8; 32]);

--- a/src/reporting/mod.rs
+++ b/src/reporting/mod.rs
@@ -3,3 +3,4 @@ pub mod mappers;
 pub mod bit_vector;
 pub mod public_report;
 pub mod symptom_inputs;
+pub mod symptom_inputs_manager;

--- a/src/reporting/symptom_inputs.rs
+++ b/src/reporting/symptom_inputs.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use super::{memo::MemoMapper, public_report::PublicReport};
 use tcn::SignedReport;
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct SymptomInputs {
   pub ids: HashSet<SymptomId>,
   pub cough: Cough,
@@ -13,39 +13,39 @@ pub struct SymptomInputs {
   pub earliest_symptom: EarliestSymptom
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Cough {
   pub cough_type: UserInput<CoughType>,
   pub days: UserInput<Days>,
   pub status: UserInput<CoughStatus>
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub enum CoughType {
   Wet, Dry
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub enum CoughStatus {
   BetterAndWorseThroughDay, WorseWhenOutside, SameOrSteadilyWorse
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Days {
   pub value: i32
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Breathlessness {
   pub cause: UserInput<BreathlessnessCause>
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub enum BreathlessnessCause {
   LeavingHouseOrDressing, WalkingYardsOrMinsOnGround, GroundOwnPace, HurryOrHill, Exercise
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Fever {
   pub days: UserInput<Days>,
   pub taken_temperature_today: UserInput<bool>,
@@ -53,18 +53,18 @@ pub struct Fever {
   pub highest_temperature: UserInput<FarenheitTemperature>
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub enum TemperatureSpot {
   Mouth, Ear, Armpit, Other(String)
 }
 
 // Temperature conversions are only for presentation, so in the apps
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct FarenheitTemperature {
   pub value: f32
 }
 
-#[derive(Eq, PartialEq, Hash, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Deserialize)]
 pub enum SymptomId {
   Cough, Breathlessness, Fever, MuscleAches, LossSmellOrTaste, Diarrhea, RunnyNose, Other, None
 }
@@ -75,7 +75,7 @@ pub enum UserInput<T> {
   None
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct EarliestSymptom {
   pub time: UserInput<UnixTime>
 }

--- a/src/reporting/symptom_inputs_manager.rs
+++ b/src/reporting/symptom_inputs_manager.rs
@@ -1,0 +1,300 @@
+
+use std::{collections::HashSet, sync::Arc};
+use super::{memo::MemoMapperImpl, symptom_inputs::{UserInput, SymptomId, Days, CoughType, CoughStatus, BreathlessnessCause, FarenheitTemperature, SymptomInputs, TemperatureSpot, SymptomInputsSubmitter}};
+use parking_lot::RwLock;
+use crate::{reports_interval::UnixTime, errors::ServicesError, tcn_ext::tcn_keys::TcnKeysImpl, networking::TcnApiImpl, preferences::PreferencesImpl};
+use chrono::{Duration, Utc};
+
+pub trait SymptomInputsProcessor {
+  fn set_symptom_ids(&self, ids: &str) -> Result<(), ServicesError>;
+  fn set_cough_type(&self, cough_type: &str) -> Result<(), ServicesError>;
+  fn set_cough_days(&self, is_set: bool, days: u32) -> Result<(), ServicesError>;
+  fn set_cough_status(&self, status: &str) -> Result<(), ServicesError>;
+  fn set_breathlessness_cause(&self, cause: &str) -> Result<(), ServicesError>;
+  fn set_fever_days(&self, is_set: bool, days: u32) -> Result<(), ServicesError>;
+  fn set_fever_taken_temperature_today(&self, is_set: bool, taken: bool) -> Result<(), ServicesError>;
+  fn set_fever_taken_temperature_spot(&self, spot: &str) -> Result<(), ServicesError>;
+  fn set_fever_highest_temperature_taken(&self, is_set: bool, temperature: f32) -> Result<(), ServicesError>;
+  fn set_earliest_symptom_started_days_ago(&self, is_set: bool, days: u32) -> Result<(), ServicesError>;
+  
+  fn submit(&self) -> Result<(), ServicesError>;
+  fn clear(&self) -> Result<(), ServicesError>;
+}
+
+pub struct SymptomInputsProcessorImpl<A> where A: SymptomInputsManager {
+  pub inputs_manager: A
+}
+
+impl <A> SymptomInputsProcessor for SymptomInputsProcessorImpl<A> where A: SymptomInputsManager {
+
+    fn set_symptom_ids(&self, ids: &str) -> Result<(), ServicesError> {
+      let inputs: Vec<&str> = serde_json::from_str(ids)?;
+
+      let mut symptom_ids = HashSet::new();
+      for str_id in inputs {
+        let symptom_id = match str_id {
+          "cough" => SymptomId::Cough,
+          "breathlessness" => SymptomId::Cough,
+          "fever" =>  SymptomId::Cough,
+          "muscle_aches" =>  SymptomId::Cough,
+          "loss_smell_or_taste" =>  SymptomId::Cough,
+          "diarrhea" =>  SymptomId::Cough,
+          "runny_nose" => SymptomId::Cough,
+          "other" =>  SymptomId::Cough,
+          "none" => SymptomId::Cough,
+          _ => Err(format!("RUST Not supported: {}", str_id))?
+        };
+        symptom_ids.insert(symptom_id);
+      }
+
+      self.inputs_manager.select_symptom_ids(symptom_ids);
+
+      Ok(())
+    }
+
+    fn set_cough_type(&self, cough_type: &str) -> Result<(), ServicesError> {
+      let input = match cough_type {
+        "none" => UserInput::None,
+        "wet" => UserInput::Some(CoughType::Wet),
+        "dry" => UserInput::Some(CoughType::Dry),
+        _ => Err(format!("Not supported: {}", cough_type))?
+      };
+
+      println!("RUST setting cough type: {:?}", input);
+
+      self.inputs_manager.set_cough_type(input);
+      Ok(())
+    }
+
+    fn set_cough_days(&self, is_set: bool, days: u32) -> Result<(), ServicesError> {
+      let input = match is_set {
+        true => UserInput::Some(Days { value: days }),
+        false => UserInput::None
+      };
+
+      println!("RUST setting cough days {:?}", input);
+ 
+      self.inputs_manager.set_cough_days(input);
+      Ok(())
+    }
+
+    fn set_cough_status(&self, status: &str) -> Result<(), ServicesError> {
+      let input = match status {
+        "none" => UserInput::None,
+        "better_and_worse" => UserInput::Some(CoughStatus::BetterAndWorseThroughDay),
+        "same_steadily_worse" => UserInput::Some(CoughStatus::SameOrSteadilyWorse),
+        "worse_outside" => UserInput::Some(CoughStatus::WorseWhenOutside),
+        _ => Err(format!("Not supported: {}", status))?
+      };
+
+      println!("RUST setting cough status: {:?}", input);
+
+      self.inputs_manager.set_cough_status(input);
+      Ok(())
+    }
+
+    fn set_breathlessness_cause(&self, cause: &str) -> Result<(), ServicesError> {
+      let input = match cause {
+        "none" => UserInput::None,
+        "exercise" => UserInput::Some(BreathlessnessCause::Exercise),
+        "leaving_house_or_dressing" => UserInput::Some(BreathlessnessCause::LeavingHouseOrDressing),
+        "walking_yards_or_mins_on_ground" => UserInput::Some(BreathlessnessCause::WalkingYardsOrMinsOnGround),
+        "ground_own_pace" => UserInput::Some(BreathlessnessCause::GroundOwnPace),
+        "hurry_or_hill" => UserInput::Some(BreathlessnessCause::HurryOrHill),
+        _ => Err(format!("Not supported: {}", cause))?
+      };
+
+      println!("RUST setting breathlessness cause: {:?}", input);
+
+      self.inputs_manager.set_breathlessness_cause(input);
+      Ok(()) 
+    }
+
+    fn set_fever_days(&self, is_set: bool, days: u32) -> Result<(), ServicesError> {
+      let input = match is_set {
+        true => UserInput::Some(Days { value: days }),
+        false => UserInput::None
+      };
+
+      println!("RUST setting fever days {:?}", input);
+ 
+      self.inputs_manager.set_fever_days(input);
+      Ok(()) 
+    }
+
+    fn set_fever_taken_temperature_today(&self, is_set: bool, taken: bool) -> Result<(), ServicesError> {
+      let input = match is_set {
+        true => UserInput::Some(taken),
+        false => UserInput::None
+      };
+
+      println!("RUST setting taken temperature today {:?}", input);
+ 
+      self.inputs_manager.set_fever_taken_temperature_today(input);
+      Ok(())  
+    }
+
+    fn set_fever_taken_temperature_spot(&self, spot: &str) -> Result<(), ServicesError> {
+      let input = match spot {
+        "none" => UserInput::None,
+        "armpit" => UserInput::Some(TemperatureSpot::Armpit),
+        "ear" => UserInput::Some(TemperatureSpot::Ear),
+        "mouth" => UserInput::Some(TemperatureSpot::Mouth),
+        "other" => UserInput::Some(TemperatureSpot::Other),
+        _ => Err(format!("Not supported: {}", spot))?
+      };
+
+      println!("RUST setting fever temperature spot: {:?}", input);
+
+      self.inputs_manager.set_fever_taken_temperature_spot(input);
+      Ok(()) 
+    }
+
+    fn set_fever_highest_temperature_taken(&self, is_set: bool, temperature: f32) -> Result<(), ServicesError> {
+      let input = match is_set {
+        true => UserInput::Some(FarenheitTemperature { value: temperature }),
+        false => UserInput::None
+      };
+
+      println!("RUST setting highest temperature taken {:?}", input);
+ 
+      self.inputs_manager.set_fever_highest_temperature_taken(input);
+      Ok(()) 
+    }
+
+    fn set_earliest_symptom_started_days_ago(&self, is_set: bool, days: u32) -> Result<(), ServicesError> {
+      let input = match is_set {
+        true => UserInput::Some(Days { value: days }),
+        false => UserInput::None
+      };
+
+      println!("RUST setting earliest symptom days ago {:?}", input);
+ 
+      self.inputs_manager.set_earliest_symptom_started_days_ago(input);
+      Ok(()) 
+    }
+
+    fn submit(&self) -> Result<(), ServicesError> {
+      self.inputs_manager.submit()
+    }
+
+    fn clear(&self) -> Result<(), ServicesError> {
+      self.inputs_manager.clear();
+      Ok(())
+    }
+}
+
+pub trait SymptomInputsManager {
+    // val inputs: SymptomInputs
+
+    fn select_symptom_ids(&self, ids: HashSet<SymptomId>);
+    fn set_cough_type(&self, input: UserInput<CoughType>);
+    fn set_cough_days(&self, input: UserInput<Days>);
+    fn set_cough_status(&self, status: UserInput<CoughStatus>);
+    fn set_breathlessness_cause(&self, cause: UserInput<BreathlessnessCause>);
+    fn set_fever_days(&self, days: UserInput<Days>);
+    fn set_fever_taken_temperature_today(&self, taken: UserInput<bool>);
+    fn set_fever_taken_temperature_spot(&self, spot: UserInput<TemperatureSpot>);
+    fn set_fever_highest_temperature_taken(&self, temp: UserInput<FarenheitTemperature>);
+    fn set_earliest_symptom_started_days_ago(&self, days: UserInput<Days>);
+    
+    fn submit(&self) -> Result<(), ServicesError>;
+    fn clear(&self);
+}
+
+pub struct SymptomInputsManagerImpl<A> where 
+  // TODO no concrete types here?
+  A: SymptomInputsSubmitter<MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>
+{
+  pub inputs: Arc<RwLock<SymptomInputs>>,
+  pub inputs_submitter: A
+}
+
+impl <A> SymptomInputsManagerImpl<A> where
+  // TODO no concrete types here?
+  A: SymptomInputsSubmitter<MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>
+{
+  fn print_current_state(&self) {
+    println!("RUST symptom inputs state: {:?}", self.inputs);
+  }
+}
+
+impl <A> SymptomInputsManager for SymptomInputsManagerImpl<A> where
+  // TODO no concrete types here?
+  A: SymptomInputsSubmitter<MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>
+{
+
+    fn select_symptom_ids(&self, ids: HashSet<SymptomId>) {
+      self.inputs.write().ids = ids;
+      self.print_current_state();
+    }
+
+    fn set_cough_type(&self, input: UserInput<CoughType>) {
+      self.inputs.write().cough.cough_type = input;
+      self.print_current_state();
+    }
+
+    fn set_cough_days(&self, input: UserInput<Days>) {
+      self.inputs.write().cough.days = input;
+      self.print_current_state();
+    }
+
+    fn set_cough_status(&self, input: UserInput<CoughStatus>) {
+      self.inputs.write().cough.status = input;
+      self.print_current_state();
+    }
+
+    fn set_breathlessness_cause(&self, input: UserInput<BreathlessnessCause>) {
+      self.inputs.write().breathlessness.cause = input;
+      self.print_current_state();
+    }
+
+    fn set_fever_days(&self, input: UserInput<Days>) {
+      self.inputs.write().fever.days = input;
+      self.print_current_state();
+    }
+
+    fn set_fever_taken_temperature_today(&self, input: UserInput<bool>) {
+      self.inputs.write().fever.taken_temperature_today = input;
+      self.print_current_state();
+    }
+
+    fn set_fever_taken_temperature_spot(&self, input: UserInput<TemperatureSpot>) {
+      self.inputs.write().fever.temperature_spot = input;
+      self.print_current_state();
+    }
+
+    fn set_fever_highest_temperature_taken(&self, input: UserInput<FarenheitTemperature>) {
+      self.inputs.write().fever.highest_temperature = input;
+      self.print_current_state();
+    }
+
+    fn set_earliest_symptom_started_days_ago(&self, input: UserInput<Days>) {
+      let time = input.map (|days| {
+        let date_time = Utc::now() - Duration::days(days.value as i64);
+        UnixTime { value: date_time.timestamp() as u64 }
+      });
+
+      self.inputs.write().earliest_symptom.time = time;
+      self.print_current_state();
+    }
+
+    fn submit(&self) -> Result<(), ServicesError> {
+      println!("RUST Submitting symptom inputs...");
+      self.print_current_state();
+      let result = self.inputs_submitter.submit_inputs(self.inputs.read().clone());
+
+      if result.is_ok() {
+        self.clear()
+      }
+      // TODO: if submit doesn't succeed, when to clear the inputs? 
+
+      result
+    }
+
+    fn clear(&self) {
+      // replace SymptomInputs instance with default or reset fields individually 
+      println!("RUST TODO implement clear symptoms");
+      self.print_current_state();
+    }
+}

--- a/src/reporting/symptom_inputs_manager.rs
+++ b/src/reporting/symptom_inputs_manager.rs
@@ -185,8 +185,6 @@ impl <A> SymptomInputsProcessor for SymptomInputsProcessorImpl<A> where A: Sympt
 }
 
 pub trait SymptomInputsManager {
-    // val inputs: SymptomInputs
-
     fn select_symptom_ids(&self, ids: HashSet<SymptomId>);
     fn set_cough_type(&self, input: UserInput<CoughType>);
     fn set_cough_days(&self, input: UserInput<Days>);

--- a/src/reporting/symptom_inputs_manager.rs
+++ b/src/reporting/symptom_inputs_manager.rs
@@ -34,14 +34,14 @@ impl <A> SymptomInputsProcessor for SymptomInputsProcessorImpl<A> where A: Sympt
       for str_id in inputs {
         let symptom_id = match str_id {
           "cough" => SymptomId::Cough,
-          "breathlessness" => SymptomId::Cough,
-          "fever" =>  SymptomId::Cough,
-          "muscle_aches" =>  SymptomId::Cough,
-          "loss_smell_or_taste" =>  SymptomId::Cough,
-          "diarrhea" =>  SymptomId::Cough,
-          "runny_nose" => SymptomId::Cough,
-          "other" =>  SymptomId::Cough,
-          "none" => SymptomId::Cough,
+          "breathlessness" => SymptomId::Breathlessness,
+          "fever" =>  SymptomId::Fever,
+          "muscle_aches" =>  SymptomId::MuscleAches,
+          "loss_smell_or_taste" => SymptomId::LossSmellOrTaste,
+          "diarrhea" =>  SymptomId::Diarrhea,
+          "runny_nose" => SymptomId::RunnyNose,
+          "other" =>  SymptomId::Other,
+          "none" => SymptomId::None,
           _ => Err(format!("RUST Not supported: {}", str_id))?
         };
         symptom_ids.insert(symptom_id);

--- a/src/reports_updater.rs
+++ b/src/reports_updater.rs
@@ -1,7 +1,7 @@
 use crate::{networking::{TcnApi, NetworkingError}, reports_interval, DB_UNINIT, DB, byte_vec_to_16_byte_array, errors::{Error, ServicesError}, preferences::{PreferencesKey, Preferences}};
 use reports_interval::{ReportsInterval, UnixTime};
 use tcn::SignedReport;
-use std::{collections::HashSet, time::Instant, rc::Rc, sync::Arc};
+use std::{collections::HashSet, time::Instant, sync::Arc};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -15,6 +15,7 @@ impl TcnMatcher for TcnMatcherImpl {
     Self::match_reports_with(tcns, reports)
   }
 }
+
 
 // TODO remove duplicate matcher functions from lib.rs
 impl TcnMatcherImpl {


### PR DESCRIPTION
I ended implementing individual setters for all the inputs, and managing the aggregate in Rust. The serialization and deserialization of the aggregate needs a custom implementation on both sides (`Encodable` in Swift and `serde` in Rust), because of the enum with associated values, which didn't seem much more convenient than setting the fields individually.