### PR TITLE
Multithreaded matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ parking_lot = "0.10.2"
 uuid = { version = "0.8.1", features = ["v4"] }
 rand = "0.7"
 hex = "0.4.2"
+rayon = "1.1"
 
 [dependencies.tcn]
 git = "https://github.com/TCNCoalition/TCN.git"

--- a/src/composition_root.rs
+++ b/src/composition_root.rs
@@ -1,5 +1,5 @@
 use crate::networking::{TcnApiImpl, TcnApi};
-use crate::reports_updater::{TcnMatcher, ReportsUpdater, TcnDao, TcnDaoImpl, TcnMatcherImpl, ObservedTcnProcessor, ObservedTcnProcessorImpl};
+use crate::reports_updater::{TcnMatcher, ReportsUpdater, TcnDao, TcnDaoImpl, TcnMatcherRayon, ObservedTcnProcessor, ObservedTcnProcessorImpl};
 use crate::{reporting::{memo::{MemoMapper, MemoMapperImpl}, symptom_inputs::{SymptomInputsSubmitterImpl, SymptomInputs}, symptom_inputs_manager::{SymptomInputsManagerImpl, SymptomInputsProcessorImpl, SymptomInputsProcessor}}, preferences::{Preferences, PreferencesImpl}, tcn_ext::tcn_keys::{TcnKeys, TcnKeysImpl}};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
@@ -25,7 +25,7 @@ pub struct CompositionRoot<'a, A, B, C, D, F, G, H, I> where
 
 pub static COMP_ROOT: Lazy<
   CompositionRoot<
-    PreferencesImpl, TcnDaoImpl, TcnMatcherImpl, TcnApiImpl, 
+    PreferencesImpl, TcnDaoImpl, TcnMatcherRayon, TcnApiImpl, 
     SymptomInputsProcessorImpl<SymptomInputsManagerImpl<SymptomInputsSubmitterImpl<MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>>>,
     ObservedTcnProcessorImpl<TcnDaoImpl>, MemoMapperImpl, TcnKeysImpl<PreferencesImpl>
   >
@@ -34,7 +34,7 @@ pub static COMP_ROOT: Lazy<
 
 
 fn create_comp_root() -> CompositionRoot<'static, 
-  PreferencesImpl, TcnDaoImpl, TcnMatcherImpl, TcnApiImpl, 
+  PreferencesImpl, TcnDaoImpl, TcnMatcherRayon, TcnApiImpl, 
   SymptomInputsProcessorImpl<SymptomInputsManagerImpl<SymptomInputsSubmitterImpl<'static, MemoMapperImpl, TcnKeysImpl<PreferencesImpl>, TcnApiImpl>>>,
   ObservedTcnProcessorImpl<'static, TcnDaoImpl>, MemoMapperImpl, TcnKeysImpl<PreferencesImpl>
 > {
@@ -59,7 +59,7 @@ fn create_comp_root() -> CompositionRoot<'static,
     reports_updater: ReportsUpdater { 
       preferences: preferences.clone(),
       tcn_dao,
-      tcn_matcher: TcnMatcherImpl {},
+      tcn_matcher: TcnMatcherRayon {},
       api,
       memo_mapper
     },

--- a/src/reports_updater.rs
+++ b/src/reports_updater.rs
@@ -97,7 +97,7 @@ impl TcnMatcherStdThreadSpawn {
 
     // TODO no unwrap
     let rep = report.clone().verify().unwrap();
-    for tcn in rep.temporary_contact_numbers().take(10) {
+    for tcn in rep.temporary_contact_numbers() {
       if let Some(entry) = observed_tcns_map.get(&tcn.0) {
         out = Some(MatchedReport { report, contact_time: entry.time.clone() });
         break;

--- a/src/reports_updater.rs
+++ b/src/reports_updater.rs
@@ -5,7 +5,9 @@ use std::{time::Instant, sync::Arc};
 use serde::Serialize;
 use uuid::Uuid;
 use chrono::Utc;
-use std::collections::HashMap;
+use std::{thread, collections::HashMap, io::Cursor};
+use thread::JoinHandle;
+use rayon::prelude::*;
 
 pub trait TcnMatcher {
   fn match_reports(&self, tcns: Vec<ObservedTcn>, reports: Vec<SignedReport>) -> Result<Vec<MatchedReport>, ServicesError>;
@@ -47,7 +49,109 @@ impl TcnMatcherImpl {
   }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+
+pub struct TcnMatcherOptimized {}
+
+impl TcnMatcher for TcnMatcherOptimized {
+  fn match_reports(&self, tcns: Vec<ObservedTcn>, reports: Vec<SignedReport>) -> Result<Vec<MatchedReport>, ServicesError> {
+    Self::match_reports_with(tcns, reports)
+  }
+}
+ 
+impl TcnMatcherOptimized {
+
+  pub fn match_reports_with(tcns: Vec<ObservedTcn>, reports: Vec<SignedReport>) -> Result<Vec<MatchedReport>, ServicesError> {
+    let observed_tcns_map: HashMap<[u8; 16], ObservedTcn> = tcns.into_iter().map(|e|
+      (e.tcn.0, e)
+    ).collect();
+
+    let observed_tcns_map = Arc::new(observed_tcns_map);
+
+    let threads: Vec<JoinHandle<Option<MatchedReport>>> = reports.into_iter().map(|report| {
+      let observed_tcns_map = observed_tcns_map.clone();
+      thread::spawn(move || Self::match_report_with(&observed_tcns_map, report)
+    )}).collect();
+
+    let res: Vec<MatchedReport> = threads
+      .into_iter()
+      .map(|t| t.join().unwrap())
+      .filter_map(|option| option) // drop None (reports that didn't match)
+      .collect();
+
+    Ok(res)
+  }
+
+  pub fn match_report_with(observed_tcns_map: &HashMap<[u8; 16], ObservedTcn>, report: SignedReport) -> Option<MatchedReport> {
+    let mut out: Option<MatchedReport> = None;
+
+    let report_str = base64::encode(signed_report_to_bytes(report.clone()));
+
+    // TODO no unwrap
+    let rep = report.clone().verify().unwrap();
+    for tcn in rep.temporary_contact_numbers().take(10) {
+      if let Some(entry) = observed_tcns_map.get(&tcn.0) {
+        out = Some(MatchedReport { report, contact_time: entry.time.clone() });
+        break;
+      }
+    }
+    out
+  }
+}
+
+fn signed_report_to_bytes(signed_report: SignedReport) -> Vec<u8> {
+  let mut buf = Vec::new();
+  signed_report.write(Cursor::new(&mut buf)).expect("Couldn't write signed report bytes");
+  buf
+}
+
+
+
+pub struct TcnMatcherRayon {}
+
+impl TcnMatcher for TcnMatcherRayon {
+  fn match_reports(&self, tcns: Vec<ObservedTcn>, reports: Vec<SignedReport>) -> Result<Vec<MatchedReport>, ServicesError> {
+    Self::match_reports_with(tcns, reports)
+  }
+}
+ 
+impl TcnMatcherRayon {
+
+  pub fn match_reports_with(tcns: Vec<ObservedTcn>, reports: Vec<SignedReport>) -> Result<Vec<MatchedReport>, ServicesError> {
+    let observed_tcns_map: HashMap<[u8; 16], ObservedTcn> = tcns.into_iter().map(|e|
+      (e.tcn.0, e)
+    ).collect();
+
+    let observed_tcns_map = Arc::new(observed_tcns_map);
+
+    let res: Vec<Option<MatchedReport>> = reports.par_iter().map(|report| {
+      Self::match_report_with(&observed_tcns_map, report) 
+    }).collect();
+    
+
+    let res: Vec<MatchedReport> = res
+      .into_iter()
+      .filter_map(|option| option) // drop None (reports that didn't match)
+      .collect();
+
+    Ok(res)
+  }
+
+  pub fn match_report_with(observed_tcns_map: &HashMap<[u8; 16], ObservedTcn>, report: &SignedReport) -> Option<MatchedReport> {
+    let mut out: Option<MatchedReport> = None;
+
+    // TODO no unwrap
+    let rep = report.clone().verify().unwrap();
+    for tcn in rep.temporary_contact_numbers() {
+      if let Some(entry) = observed_tcns_map.get(&tcn.0) {
+        out = Some(MatchedReport { report: report.clone(), contact_time: entry.time.clone() });
+        break;
+      }
+    }
+    out
+  }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ObservedTcn { tcn: TemporaryContactNumber, time: UnixTime }
 
 impl ObservedTcn {
@@ -160,6 +264,21 @@ pub struct ReportsUpdater<'a,
   pub memo_mapper: &'a MemoMapperType,
 }
 
+trait SignedReportExt {
+  fn with_str(str: &str) -> Option<SignedReport> {
+    base64::decode(str)
+    .map(|bytes| SignedReport::read( bytes.as_slice()).unwrap())
+    .also(|res| if res.is_err() { print!("error!"); })
+    .map_err(|err| {
+      println!("Error: {}", err);
+      err
+    })
+    .ok()
+  }
+}
+impl SignedReportExt for SignedReport {}
+
+
 impl<'a, 
   PreferencesType: Preferences, TcnDaoType: TcnDao, TcnMatcherType: TcnMatcher, ApiType: TcnApi, MemoMapperType: MemoMapper
 > ReportsUpdater<'a, PreferencesType, TcnDaoType, TcnMatcherType, ApiType, MemoMapperType> {
@@ -242,7 +361,7 @@ impl<'a,
             reports: report_strings
               .into_iter()
               .filter_map(|report_string|
-                Self::to_signed_report(&report_string).also(|res|
+                SignedReport::with_str(&report_string).also(|res|
                     if res.is_none() {
                         println!("Failed to convert report string: $it to report");
                     }
@@ -302,18 +421,7 @@ impl<'a,
 
     matched_reports
   }
-
-  fn to_signed_report(report_string: &str) -> Option<SignedReport> {
-    base64::decode(report_string)
-    .map(|bytes| SignedReport::read( bytes.as_slice()).unwrap())
-    .also(|res| if res.is_err() { print!("error!"); })
-    .map_err(|err| {
-      println!("Error: {}", err);
-      err
-    })
-    .ok()
-  }
-
+  
   fn interval_ending_before(mut intervals: Vec<ReportsInterval>, time: &UnixTime) -> Option<ReportsInterval> {
     // TODO shorter version of this?
     let reversed: Vec<ReportsInterval> = intervals.into_iter().rev().collect();
@@ -356,6 +464,9 @@ struct SignedReportsChunk {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use tcn::{MemoType, ReportAuthorizationKey};
+  use crate::reporting::memo::MemoMapperImpl;
+  use std::io::Cursor;
 
   #[test]
   fn tcn_saved_and_restored_from_bytes() {
@@ -368,5 +479,55 @@ mod tests {
     let observed_tcn_as_bytes = observed_tcn.as_bytes();
     let observed_tc_from_bytes = ObservedTcn::from_bytes(observed_tcn_as_bytes);
     assert_eq!(observed_tc_from_bytes, observed_tcn);
+  }
+
+  fn create_test_report() -> SignedReport {
+    let memo_mapper = MemoMapperImpl {};
+    let public_report = PublicReport {
+      earliest_symptom_time: UserInput::Some(UnixTime { value: 1589209754 }),
+      fever_severity: FeverSeverity::Serious,
+      breathlessness: true,
+      cough_severity: CoughSeverity::Existing
+    };
+    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+    let memo_data = memo_mapper.to_memo(public_report, UnixTime { value: 1589209754 });
+    rak.create_report(MemoType::CoEpiV1, memo_data.bytes, 1, 10000).unwrap()
+  }
+
+  #[test]
+  fn matching_benchmark() {
+
+    let verification_report_str = "D7Z8XrufMgfsFH3K5COnv17IFG2ahDb4VM/UMK/5y0+/OtUVVTh7sN0DQ5+R+ocecTilR+SIIpPHzujeJdJzugEAECcAFAEAmmq5XgAAAACaarleAAAAACEBo8p1WdGeXb5O5/3kN6x7GSylgiYGIGsABl3NrxhJu9XHwsN3f6yvRwUxs2fhP4oU5E3+JWabBP6v09pGV1xRCw==";
+    let verification_report_tcn: [u8; 16] = [24, 229, 125, 245, 98, 86, 219, 221, 172, 25, 232, 150, 206, 66, 164, 173]; // belongs to report
+    let verification_contact_time =  UnixTime { value: 1590528300 };
+    let verification_report = SignedReport::with_str(verification_report_str).unwrap();
+
+    let mut reports: Vec<SignedReport> = vec![0; 10000].into_iter().map(|_| create_test_report()).collect();
+    reports.push(verification_report);
+
+    // let matcher = TcnMatcherImpl {}; // 20 -> 6s, 200 -> 64s, 1000 -> 317s, 10000 ->
+    // let matcher = TcnMatcherOptimized {}; // 20 -> 1s, 200 -> 16s, 1000 -> 84s, 10000 ->
+    let matcher = TcnMatcherRayon {}; // 20 -> 1s, 200 -> 7s, 1000 -> 87s, 10000 -> 927s
+
+    let tcns = vec![
+      ObservedTcn { tcn: TemporaryContactNumber([0; 16]), time: UnixTime { value: 1590528300 } },
+      ObservedTcn { tcn: TemporaryContactNumber(verification_report_tcn), time:  verification_contact_time.clone() },
+      ObservedTcn { tcn: TemporaryContactNumber([1; 16]), time: UnixTime { value: 1590528300 } },
+    ];
+
+    let matching_start_time = Instant::now();
+
+    let res = matcher.match_reports(tcns, reports);
+
+    let matches = res.unwrap();
+    assert_eq!(matches.len(), 1);
+
+    let time = matching_start_time.elapsed().as_secs();
+    println!("Took {:?}s to match reports", time);
+
+    // Short verification that matching is working
+    let matched_report_str = base64::encode(signed_report_to_bytes(matches[0].report.clone()));
+    assert_eq!(matched_report_str, verification_report_str);
+    assert_eq!(matches[0].contact_time, verification_contact_time);
   }
 }


### PR DESCRIPTION
Added 2 approaches:
- `std::thread::spawn` (no thread pool)
- Using [rayon](https://github.com/rayon-rs/rayon) crate

Benchmarks so far (tested on my computer):
3 stored TCNs
all reports have j1=1, j2=10000
report count -> time
- Default implementation: 
20 -> 6s, 200 -> 64s, 1000 -> 317s, 10000 -> ?
- `std::thread::spawn`: 
20 -> 1s, 200 -> 16s, 1000 -> 84s, 10000 -> ?
- rayon: 
20 -> 1s, 200 -> 7s, 1000 -> 87s, 10000 -> 927s