### PR TITLE
Specify TCN library revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ rayon = "1.1"
 
 [dependencies.tcn]
 git = "https://github.com/TCNCoalition/TCN.git"
-branch = "main"
+rev = "c8de5a7a6a0bd681f69f27e77a493832af47e482"


### PR DESCRIPTION
This change is discussable. Alternatively we can remove Cargo.lock from the .gitignore, which would [probably be appropriate for the way we use this library](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries), but I don't want to exclude yet that it will be used in contexts where it may be a problem.