### PR TITLE
Fix new RAK generated on each access

### DIFF
--- a/src/reports_updater.rs
+++ b/src/reports_updater.rs
@@ -525,6 +525,19 @@ mod tests {
         assert_eq!(observed_tc_from_bytes, observed_tcn);
     }
 
+    // Utility to see quickly all TCNs (hex) for a report
+    // #[test]
+    // fn print_tcns_for_report() {
+    //     let report_str = "rOFMgzy3y36MJns34Xj7EZu5Dti9XMhYGRpa/DVznep6q4hMtMYm9sYMg9+sRSHAj0Ff2rHTPXskuzJH0+pZMQEAAgAAFAEAnazaXgAAAAD//////////wMAMFLrKLNOvwUJQSNta9rlzTyjFdpfq25Kv34c6y+ZOoSzRewzNAWsd56Yzm8LUw9cpHB8yyzDUMJ9YTKhD8dADA==";
+    //     let report = SignedReport::with_str(report_str).unwrap();
+
+    //     println!("{:?}", report);
+
+    //     for tcn in report.verify().unwrap().temporary_contact_numbers() {
+    //         println!("{}", hex::encode(tcn.0));
+    //     }
+    // }
+
     #[test]
     fn matching_benchmark() {
         let verification_report_str = "D7Z8XrufMgfsFH3K5COnv17IFG2ahDb4VM/UMK/5y0+/OtUVVTh7sN0DQ5+R+ocecTilR+SIIpPHzujeJdJzugEAECcAFAEAmmq5XgAAAACaarleAAAAACEBo8p1WdGeXb5O5/3kN6x7GSylgiYGIGsABl3NrxhJu9XHwsN3f6yvRwUxs2fhP4oU5E3+JWabBP6v09pGV1xRCw==";

--- a/src/tcn_ext/tcn_keys.rs
+++ b/src/tcn_ext/tcn_keys.rs
@@ -77,6 +77,7 @@ where
             .authorization_key()
             .map(|rak_bytes| ReportAuthorizationKey::with_bytes(rak_bytes)) //Self::bytes_to_rak(rak_bytes))
             .unwrap_or({
+            .unwrap_or_else(|| {
                 let new_key = ReportAuthorizationKey::new(rand::thread_rng());
                 self.preferences
                     .set_autorization_key(Self::rak_to_bytes(new_key));

--- a/src/tcn_ext/tcn_keys.rs
+++ b/src/tcn_ext/tcn_keys.rs
@@ -76,7 +76,6 @@ where
         self.preferences
             .authorization_key()
             .map(|rak_bytes| ReportAuthorizationKey::with_bytes(rak_bytes)) //Self::bytes_to_rak(rak_bytes))
-            .unwrap_or({
             .unwrap_or_else(|| {
                 let new_key = ReportAuthorizationKey::new(rand::thread_rng());
                 self.preferences


### PR DESCRIPTION
This was causing reports created on iOS not being matched, as the TCN and the report were generated with different RAKs.