### PR TITLE
Remove or comment uses of unwrap()

### DIFF
--- a/src/composition_root.rs
+++ b/src/composition_root.rs
@@ -80,6 +80,10 @@ fn create_comp_root() -> CompositionRoot<
 > {
     let api = &TcnApiImpl {};
     let preferences = Arc::new(PreferencesImpl {
+        // unwrap: "Errors that are returned from this function are I/O related,
+        // for example if the writing of the new configuration fails or confy encounters
+        // an operating system or environment that it does not support."
+        // The config is critical in this app, so it's ok to crash if not available.
         config: RwLock::new(confy::load("coepi").unwrap()),
     });
     let memo_mapper = &MemoMapperImpl {};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,69 +1,79 @@
 use crate::networking::NetworkingError;
-use std::{io::ErrorKind, fmt, error, io::Error as StdError};
+use std::{error, fmt, io::Error as StdError, io::ErrorKind};
 use tcn::Error as TcnError;
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[derive(Debug)]
 pub enum ServicesError {
-  Networking(NetworkingError),
-  Error(Error)
+    Networking(NetworkingError),
+    Error(Error),
+    FFIParameters(String),
 }
 
 impl fmt::Display for ServicesError {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-      write!(f, "{:?}", self)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl From<Error> for ServicesError {
-  fn from(error: Error) -> Self {
-    ServicesError::Error(error)
-  }
+    fn from(error: Error) -> Self {
+        ServicesError::Error(error)
+    }
 }
 
 impl From<NetworkingError> for ServicesError {
-  fn from(error: NetworkingError) -> Self {
-    ServicesError::Networking(error)
-  }
+    fn from(error: NetworkingError) -> Self {
+        ServicesError::Networking(error)
+    }
 }
 
 impl From<TcnError> for ServicesError {
-  fn from(error: TcnError) -> Self {
-    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, format!("{}", error))))
-  }
+    fn from(error: TcnError) -> Self {
+        ServicesError::Error(Box::new(StdError::new(
+            ErrorKind::Other,
+            format!("{}", error),
+        )))
+    }
 }
 
 impl From<String> for ServicesError {
-  fn from(error: String) -> Self {
-    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, error)))
-  }
+    fn from(error: String) -> Self {
+        ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, error)))
+    }
 }
 
 impl From<&str> for ServicesError {
-  fn from(error: &str) -> Self {
-    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, error)))
-  }
+    fn from(error: &str) -> Self {
+        ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, error)))
+    }
 }
 
 impl From<serde_json::Error> for ServicesError {
-  fn from(error: serde_json::Error) -> Self {
-    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, format!("{}", error))))
-  }
+    fn from(error: serde_json::Error) -> Self {
+        ServicesError::Error(Box::new(StdError::new(
+            ErrorKind::Other,
+            format!("{}", error),
+        )))
+    }
 }
-
 
 impl From<persy::PersyError> for ServicesError {
-  fn from(error: persy::PersyError) -> Self {
-    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, format!("{}", error))))
-  }
+    fn from(error: persy::PersyError) -> Self {
+        ServicesError::Error(Box::new(StdError::new(
+            ErrorKind::Other,
+            format!("{}", error),
+        )))
+    }
 }
-
 
 impl From<hex::FromHexError> for ServicesError {
-  fn from(error: hex::FromHexError) -> Self {
-    ServicesError::Error(Box::new(StdError::new(ErrorKind::Other, format!("{}", error))))
-  }
+    fn from(error: hex::FromHexError) -> Self {
+        ServicesError::Error(Box::new(StdError::new(
+            ErrorKind::Other,
+            format!("{}", error),
+        )))
+    }
 }
-
 
 impl error::Error for ServicesError {}

--- a/src/ios/ios_interface.rs
+++ b/src/ios/ios_interface.rs
@@ -1,18 +1,13 @@
 use crate::reports_updater::ObservedTcnProcessor;
 use crate::tcn_ext::tcn_keys::TcnKeys;
-use crate::{
-    composition_root::COMP_ROOT,
-    errors::ServicesError::{self},
-    networking,
-    simple_logger,
-};
+use crate::{composition_root::COMP_ROOT, errors::ServicesError, networking, simple_logger};
 use crate::{init_db, reporting::symptom_inputs_manager::SymptomInputsProcessor};
 use core_foundation::base::TCFType;
 use core_foundation::string::{CFString, CFStringRef};
+use log::*;
 use networking::TcnApi;
 use serde::Serialize;
 use std::os::raw::c_char;
-use log::*;
 
 // Generic struct to return results to app
 // For convenience, status will be HTTP status codes
@@ -25,13 +20,13 @@ struct LibResult<T> {
 
 #[no_mangle]
 pub unsafe extern "C" fn bootstrap_core(db_path: *const c_char) -> CFStringRef {
-    let db_path_str = cstring_to_str(&db_path).unwrap();
+    let db_path_str = cstring_to_str(&db_path);
 
     println!("RUST: bootstrapping with db path: {:?}", db_path_str);
     //TODO: Investigate using Box-ed logger
     //TODO: let app set max_logging_level
     let _ = simple_logger::init();
-    let result = init_db(db_path_str).map_err(ServicesError::from);
+    let result = db_path_str.and_then(|path| init_db(path).map_err(ServicesError::from));
     // println!("RUST: bootstrapping result: {:?}", result);
     info!("RUST: bootstrapping result: {:?}", result);
     return to_result_str(result);
@@ -50,14 +45,14 @@ pub unsafe extern "C" fn fetch_new_reports() -> CFStringRef {
 
 #[no_mangle]
 pub unsafe extern "C" fn record_tcn(c_tcn: *const c_char) -> CFStringRef {
-    // TODO don't unwrap, use and handle result, handle
-    let tcn_str = cstring_to_str(&c_tcn).unwrap();
+    let tcn_str = cstring_to_str(&c_tcn);
     info!("RUST: recording a TCN {:?}", c_tcn);
-    let result = COMP_ROOT.observed_tcn_processor.save(tcn_str);
+    let result = tcn_str.and_then(|tcn_str| COMP_ROOT.observed_tcn_processor.save(tcn_str));
     info!("RUST: recording TCN result {:?}", result);
     return to_result_str(result);
 }
 
+// NOTE: Returns directly success string
 #[no_mangle]
 pub unsafe extern "C" fn generate_tcn() -> CFStringRef {
     // TODO hex encoding in component, or send byte array directly?
@@ -71,42 +66,6 @@ pub unsafe extern "C" fn generate_tcn() -> CFStringRef {
     ::std::mem::forget(cf_string);
 
     cf_string_ref
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn get_reports(interval_number: u32, interval_length: u32) -> CFStringRef {
-    info!(
-        "RUST: fetching reports for interval_number: {}, interval_length {}",
-        interval_number, interval_length
-    );
-
-    let result = COMP_ROOT
-        .api
-        .get_reports(interval_number as u64, interval_length as u64);
-
-    info!("RUST: Api returned: {:?}", result);
-
-    let lib_result = match result {
-        Ok(success) => LibResult {
-            status: 200,
-            data: Some(success),
-            error_message: None,
-        },
-        Err(e) => LibResult {
-            status: e.http_status,
-            data: None,
-            error_message: Some(e.to_string()),
-        },
-    };
-
-    let lib_result_string = serde_json::to_string(&lib_result).unwrap();
-
-    let cf_string = CFString::new(&lib_result_string);
-    let cf_string_ref = cf_string.as_concrete_TypeRef();
-
-    ::std::mem::forget(cf_string);
-
-    return cf_string_ref;
 }
 
 fn to_result_str<T: Serialize>(result: Result<T, ServicesError>) -> CFStringRef {
@@ -124,7 +83,8 @@ fn to_result_str<T: Serialize>(result: Result<T, ServicesError>) -> CFStringRef 
         },
     };
 
-    let lib_result_string = serde_json::to_string(&lib_result).unwrap();
+    let lib_result_string =
+        serde_json::to_string(&lib_result).unwrap_or_else(|_| fallback_error_result_str::<T>());
 
     let cf_string = CFString::new(&lib_result_string);
     let cf_string_ref = cf_string.as_concrete_TypeRef();
@@ -134,23 +94,34 @@ fn to_result_str<T: Serialize>(result: Result<T, ServicesError>) -> CFStringRef 
     return cf_string_ref;
 }
 
+fn fallback_error_result_str<T: Serialize>() -> String {
+    serde_json::to_string(&LibResult::<T> {
+        status: 500,
+        data: None,
+        error_message: Some("Couldn't serialize result".to_owned()),
+    })
+    // unwrap: safe, since we are using a hardcoded value
+    .unwrap()
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn set_symptom_ids(c_ids: *const c_char) -> CFStringRef {
     debug!("RUST: setting symptom ids: {:?}", c_ids);
-    // TODO don't unwrap, use and handle result, handle
-    let ids_str = cstring_to_str(&c_ids).unwrap();
-    let result = COMP_ROOT.symptom_inputs_processor.set_symptom_ids(ids_str);
+    let ids_str = cstring_to_str(&c_ids);
+    let result =
+        ids_str.and_then(|ids_str| COMP_ROOT.symptom_inputs_processor.set_symptom_ids(ids_str));
     return to_result_str(result);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn set_cough_type(c_cough_type: *const c_char) -> CFStringRef {
     debug!("RUST: setting cough type: {:?}", c_cough_type);
-    // TODO don't unwrap, use and handle result, handle
-    let cough_type_str = cstring_to_str(&c_cough_type).unwrap();
-    let result = COMP_ROOT
-        .symptom_inputs_processor
-        .set_cough_type(cough_type_str);
+    let cough_type_str = cstring_to_str(&c_cough_type);
+    let result = cough_type_str.and_then(|cough_type_str| {
+        COMP_ROOT
+            .symptom_inputs_processor
+            .set_cough_type(cough_type_str)
+    });
     return to_result_str(result);
 }
 
@@ -165,22 +136,24 @@ pub unsafe extern "C" fn set_cough_days(c_is_set: u8, c_days: u32) -> CFStringRe
 #[no_mangle]
 pub unsafe extern "C" fn set_cough_status(c_status: *const c_char) -> CFStringRef {
     debug!("RUST: setting cough status: {:?}", c_status);
-    // TODO don't unwrap, use and handle result, handle
-    let status_str = cstring_to_str(&c_status).unwrap();
-    let result = COMP_ROOT
-        .symptom_inputs_processor
-        .set_cough_status(status_str);
+    let status_str = cstring_to_str(&c_status);
+    let result = status_str.and_then(|status_str| {
+        COMP_ROOT
+            .symptom_inputs_processor
+            .set_cough_status(status_str)
+    });
     return to_result_str(result);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn set_breathlessness_cause(c_cause: *const c_char) -> CFStringRef {
     debug!("RUST: setting breathlessness cause: {:?}", c_cause);
-    // TODO don't unwrap, use and handle result, handle
-    let cause_str = cstring_to_str(&c_cause).unwrap();
-    let result = COMP_ROOT
-        .symptom_inputs_processor
-        .set_breathlessness_cause(cause_str);
+    let cause_str = cstring_to_str(&c_cause);
+    let result = cause_str.and_then(|cause_str| {
+        COMP_ROOT
+            .symptom_inputs_processor
+            .set_breathlessness_cause(cause_str)
+    });
     return to_result_str(result);
 }
 
@@ -206,11 +179,12 @@ pub unsafe extern "C" fn set_fever_taken_temperature_today(
 #[no_mangle]
 pub unsafe extern "C" fn set_fever_taken_temperature_spot(c_cause: *const c_char) -> CFStringRef {
     debug!("RUST: setting temperature spot cause: {:?}", c_cause);
-    // TODO don't unwrap, use and handle result, handle
-    let spot_str = cstring_to_str(&c_cause).unwrap();
-    let result = COMP_ROOT
-        .symptom_inputs_processor
-        .set_fever_taken_temperature_spot(spot_str);
+    let spot_str = cstring_to_str(&c_cause);
+    let result = spot_str.and_then(|spot_str| {
+        COMP_ROOT
+            .symptom_inputs_processor
+            .set_fever_taken_temperature_spot(spot_str)
+    });
     return to_result_str(result);
 }
 
@@ -252,57 +226,27 @@ pub unsafe extern "C" fn submit_symptoms() -> CFStringRef {
 pub unsafe extern "C" fn post_report(c_report: *const c_char) -> CFStringRef {
     info!("RUST: posting report: {:?}", c_report);
 
-    // TODO don't unwrap, use and handle result, handle
-    let report = cstring_to_str(&c_report).unwrap();
+    let report = cstring_to_str(&c_report);
 
-    let result = COMP_ROOT.api.post_report(report.to_owned());
+    let result = report.and_then(|report| {
+        COMP_ROOT
+            .api
+            .post_report(report.to_owned())
+            .map_err(ServicesError::from)
+    });
 
-    let lib_result: LibResult<()> = match result {
-        Ok(_) => LibResult {
-            status: 200,
-            data: None,
-            error_message: None,
-        },
-        Err(e) => LibResult {
-            status: e.http_status,
-            data: None,
-            error_message: Some(e.to_string()),
-        },
-    };
-
-    let lib_result_string = serde_json::to_string(&lib_result).unwrap();
-
-    let cf_string = CFString::new(&lib_result_string);
-    let cf_string_ref = cf_string.as_concrete_TypeRef();
-
-    ::std::mem::forget(cf_string);
-
-    return cf_string_ref;
+    return to_result_str(result);
 }
 
 // Convert C string to Rust string slice
-pub unsafe fn cstring_to_str<'a>(cstring: &'a *const c_char) -> Option<&str> {
+pub unsafe fn cstring_to_str<'a>(cstring: &'a *const c_char) -> Result<&str, ServicesError> {
     if cstring.is_null() {
-        return None;
+        return Err(ServicesError::FFIParameters("cstring is null".to_owned()));
     }
 
     let raw = ::std::ffi::CStr::from_ptr(*cstring);
     match raw.to_str() {
-        Ok(s) => Some(s),
-        Err(_) => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_get_reports() {
-        unsafe {
-            let res = get_reports(1, 21600);
-            debug!("reports: {:?}", res);
-            assert!(true);
-        }
+        Ok(s) => Ok(s),
+        Err(e) => Err(ServicesError::FFIParameters(e.to_string())),
     }
 }

--- a/src/reporting/bit_vector.rs
+++ b/src/reporting/bit_vector.rs
@@ -23,7 +23,7 @@ impl BitVector {
             .map(|chunk| {
                 let bit_string = Self::to_bit_string(chunk);
                 let reversed: String = bit_string.chars().rev().collect(); // Most significant bit first
-                u8::from_str_radix(reversed.as_ref(), 2).unwrap()
+                u8::from_str_radix(reversed.as_ref(), 2).unwrap() // unwrap: we know that the chunks have 8 bits (are not empty) and composed of 1 and 0.
             })
             .collect()
     }
@@ -94,5 +94,17 @@ impl BitVector {
             mut_vec.push(with);
         }
         mut_vec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn bit_vector_generates_empty_byte_array_if_empty() {
+        let bit_vector = BitVector { bits: vec![] };
+        let u8_array = bit_vector.as_u8_array();
+
+        assert!(u8_array.is_empty());
     }
 }

--- a/src/reporting/mappers.rs
+++ b/src/reporting/mappers.rs
@@ -103,6 +103,8 @@ impl BitMapper<bool> for BoolMapper {
     }
 
     fn from_bits_unchecked(&self, bit_vector: BitVector) -> bool {
+        // unwrap: we know that _currently_ bit_vector can't be empty (because of the payload and memo's max length)
+        // TODO safer. Ideally without having to change interface to return Result.
         bit_vector.bits.first().unwrap().to_owned()
     }
 }

--- a/src/reporting/symptom_inputs.rs
+++ b/src/reporting/symptom_inputs.rs
@@ -3,10 +3,10 @@ use crate::{
     errors::ServicesError, networking::TcnApi, reports_interval::UnixTime,
     tcn_ext::tcn_keys::TcnKeys,
 };
+use log::*;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, io::Cursor, sync::Arc};
 use tcn::SignedReport;
-use log::*;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct SymptomInputs {
@@ -195,17 +195,17 @@ mod tests {
     use crate::errors::ServicesError::Error;
     use crate::preferences::PreferencesTckMock;
     use crate::reporting::memo::MemoMapperImpl;
+    use crate::simple_logger;
     use crate::{
         networking::TcnApiMock,
         tcn_ext::tcn_keys::{ReportAuthorizationKeyExt, TcnKeysImpl},
     };
     use tcn::{ReportAuthorizationKey, TemporaryContactKey};
-    use crate::simple_logger;
 
     #[test]
     fn test_public_report_with_inputs() {
         let _ = simple_logger::init();
-        
+
         let breathlessness = Breathlessness {
             cause: UserInput::Some(BreathlessnessCause::HurryOrHill),
         };
@@ -351,6 +351,7 @@ mod tests {
         let mut tck = rak.initial_temporary_contact_key(); // tck <- tck_1
                                                            // let mut tcns = Vec::new();
         for _ in 0..index {
+            // unwrap: this function is used only in tests
             tck = tck.ratchet().unwrap();
         }
 
@@ -437,6 +438,7 @@ mod tests {
             Ok(()) => assert!(true),
             Err(errors::ServicesError::Networking(_)) => assert!(false),
             Err(Error(_)) => assert!(false),
+            Err(_) => assert!(false),
         }
     }
 }

--- a/src/tcn_ext/tcn_keys.rs
+++ b/src/tcn_ext/tcn_keys.rs
@@ -1,10 +1,10 @@
 use crate::preferences::{Preferences, TckBytesWrapper, TCK_SIZE_IN_BYTES};
+use log::*;
 use std::{io::Cursor, sync::Arc};
 use tcn::{
     Error, MemoType, ReportAuthorizationKey, SignedReport, TemporaryContactKey,
     TemporaryContactNumber,
 };
-use log::*;
 
 pub trait TcnKeys {
     fn create_report(&self, report: Vec<u8>) -> Result<SignedReport, Error>;
@@ -89,7 +89,7 @@ where
         self.preferences
             .tck()
             .map(|tck_bytes| Self::bytes_to_tck(tck_bytes))
-            .unwrap_or({ self.rak().initial_temporary_contact_key() })
+            .unwrap_or_else(|| self.rak().initial_temporary_contact_key())
     }
 
     fn set_tck(&self, tck: TemporaryContactKey) {


### PR DESCRIPTION
Note: Removed:
- Thread spawn matcher, since it needed modifications and we're unlikely to use it.
- get_reports FFI function: We're not calling directly the API from the app anymore.