### PR TITLE
Added --release flag to android build script

### DIFF
--- a/scripts/android/create_android.sh
+++ b/scripts/android/create_android.sh
@@ -17,17 +17,20 @@ fi
 
 # See https://github.com/Co-Epi/app-backend-rust/wiki/Building-library-for-Android
 
-# debug builds
-cargo ndk --platform 29 --target x86_64-linux-android build
-cargo ndk --platform 29 --target aarch64-linux-android build
-cargo ndk --platform 29 --target armv7-linux-androideabi build
-cargo ndk --platform 29 --target i686-linux-android build
+if [[ $* == *--release* ]]; then
+    # release builds
+    cargo ndk --platform 29 --target x86_64-linux-android build --release
+    cargo ndk --platform 29 --target aarch64-linux-android build --release
+    cargo ndk --platform 29 --target armv7-linux-androideabi build --release
+    cargo ndk --platform 29 --target i686-linux-android build --release
+else
+    # debug builds
+    cargo ndk --platform 29 --target x86_64-linux-android build
+    cargo ndk --platform 29 --target aarch64-linux-android build
+    cargo ndk --platform 29 --target armv7-linux-androideabi build
+    cargo ndk --platform 29 --target i686-linux-android build
+fi
 
-# release builds
-# cargo ndk --platform 29 --target x86_64-linux-android build --release
-# cargo ndk --platform 29 --target aarch64-linux-android build --release
-# cargo ndk --platform 29 --target armv7-linux-androideabi build --release
-# cargo ndk --platform 29 --target i686-linux-android build --release
 
 # Linking ###########################################################
 
@@ -37,6 +40,7 @@ echo "Copying library files to Android app: ${PATH_TO_ANDROID_REPO}"
 
 PATH_TO_ANDROID_MAIN=$PATH_TO_ANDROID_REPO/app/src/main
 
+rm -fr $PATH_TO_ANDROID_MAIN/jniLibs
 mkdir $PATH_TO_ANDROID_MAIN/jniLibs
 mkdir $PATH_TO_ANDROID_MAIN/jniLibs/arm64
 mkdir $PATH_TO_ANDROID_MAIN/jniLibs/arm64-v8a
@@ -44,16 +48,18 @@ mkdir $PATH_TO_ANDROID_MAIN/jniLibs/armeabi
 mkdir $PATH_TO_ANDROID_MAIN/jniLibs/x86_64
 mkdir $PATH_TO_ANDROID_MAIN/jniLibs/x86
 
-# debug
-ln -s $(pwd)/target/aarch64-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64/libcoepi_core.so
-ln -s $(pwd)/target/aarch64-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64-v8a/libcoepi_core.so
-ln -s $(pwd)/target/x86_64-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86_64/libcoepi_core.so
-ln -s $(pwd)/target/armv7-linux-androideabi/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/armeabi/libcoepi_core.so
-ln -s $(pwd)/target/i686-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86/libcoepi_core.so
-
-# release
-# ln -s $(pwd)/target/aarch64-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64/libcoepi_core.so
-# ln -s $(pwd)/target/aarch64-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64-v8a/libcoepi_core.so
-# ln -s $(pwd)/target/x86_64-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86_64/libcoepi_core.so
-# ln -s $(pwd)/target/armv7-linux-androideabi/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/armeabi/libcoepi_core.so
-# ln -s $(pwd)/target/i686-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86/libcoepi_core.so
+if [[ $* == *--release* ]]; then
+    # release
+    cp $(pwd)/target/aarch64-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64/libcoepi_core.so
+    cp $(pwd)/target/aarch64-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64-v8a/libcoepi_core.so
+    cp $(pwd)/target/x86_64-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86_64/libcoepi_core.so
+    cp $(pwd)/target/armv7-linux-androideabi/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/armeabi/libcoepi_core.so
+    cp $(pwd)/target/i686-linux-android/release/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86/libcoepi_core.so
+else
+    # debug
+    cp $(pwd)/target/aarch64-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64/libcoepi_core.so
+    cp $(pwd)/target/aarch64-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/arm64-v8a/libcoepi_core.so
+    cp $(pwd)/target/x86_64-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86_64/libcoepi_core.so
+    cp $(pwd)/target/armv7-linux-androideabi/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/armeabi/libcoepi_core.so
+    cp $(pwd)/target/i686-linux-android/debug/libcoepi_core.so $PATH_TO_ANDROID_MAIN/jniLibs/x86/libcoepi_core.so
+fi


### PR DESCRIPTION
Also, instead of a symlink, the jniLibs folder is removed and the binaries are copied instead of symlinked. 