### PR TITLE
Link alerts

### DIFF
--- a/android/core/core/src/androidTest/java/org/coepi/core/JNIInterfaceTests.kt
+++ b/android/core/core/src/androidTest/java/org/coepi/core/JNIInterfaceTests.kt
@@ -63,7 +63,7 @@ class JNIInterfaceTests {
             JniAlertsArrayResult(
                 1, "", arrayOf(
                     JniAlert(
-                        "123", JniPublicReport(
+                        "123", JniPublicSymptoms(
                             reportTime = 131321,
                             earliestSymptomTime = 1590356601,
                             feverSeverity = 1,
@@ -78,7 +78,7 @@ class JNIInterfaceTests {
                         ), 1592567315, 1592567335, 1.2f, 2.1f
                     ),
                     JniAlert(
-                        "343356", JniPublicReport(
+                        "343356", JniPublicSymptoms(
                             reportTime = 32516899200,
                             earliestSymptomTime = 1590356601,
                             feverSeverity = 1,

--- a/android/core/core/src/androidTest/java/org/coepi/core/JNIInterfaceTests.kt
+++ b/android/core/core/src/androidTest/java/org/coepi/core/JNIInterfaceTests.kt
@@ -7,7 +7,7 @@ import org.coepi.core.jni.JniAlert
 import org.coepi.core.jni.JniAlertsArrayResult
 import org.coepi.core.jni.JniApi
 import org.coepi.core.jni.JniOneAlertResult
-import org.coepi.core.jni.JniPublicReport
+import org.coepi.core.jni.JniPublicSymptoms
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -36,7 +36,7 @@ class JNIInterfaceTests {
         assertEquals(
             JniOneAlertResult(
                 1, "", JniAlert(
-                    "123", JniPublicReport(
+                    "123", JniPublicSymptoms(
                         reportTime = 234324,
                         earliestSymptomTime = 1590356601,
                         feverSeverity = 1,

--- a/android/core/core/src/main/java/org/coepi/core/jni/JniApi.kt
+++ b/android/core/core/src/main/java/org/coepi/core/jni/JniApi.kt
@@ -134,14 +134,14 @@ data class JniAlertsArrayResult(
 
 data class JniAlert(
     var id: String,
-    var report: JniPublicReport,
+    var report: JniPublicSymptoms,
     var contactStart: Long,
     var contactEnd: Long,
     var minDistance: Float,
     var avgDistance: Float
 )
 
-data class JniPublicReport(
+data class JniPublicSymptoms(
     val reportTime: Long,
     val earliestSymptomTime: Long, // -1 -> no input
     val feverSeverity: Int,

--- a/src/android/android_interface.rs
+++ b/src/android/android_interface.rs
@@ -7,7 +7,7 @@ use crate::{
     errors::ServicesError,
     expect_log,
     reporting::{
-        public_report::{CoughSeverity, FeverSeverity, PublicReport},
+        public_symptoms::{CoughSeverity, FeverSeverity, PublicSymptoms},
         symptom_inputs::UserInput,
     },
     reports_interval::UnixTime,
@@ -565,7 +565,7 @@ fn register_callback_internal(callback: Box<dyn LogCallbackWrapper>) {
 
 // To prefill the JNI array (TODO can this be skipped?)
 fn placeholder_alert() -> Alert {
-    let report = PublicReport {
+    let report = PublicSymptoms {
         report_time: UnixTime { value: 0 },
         earliest_symptom_time: UserInput::Some(UnixTime { value: 0 }),
         fever_severity: FeverSeverity::None,
@@ -590,7 +590,7 @@ fn placeholder_alert() -> Alert {
 }
 
 pub fn alert_to_jobject(alert: Alert, env: &JNIEnv) -> Result<jobject, ServicesError> {
-    let jni_public_report_class = env.find_class("org/coepi/core/jni/JniPublicReport")?;
+    let jni_public_symptoms_class = env.find_class("org/coepi/core/jni/JniPublicSymptoms")?;
 
     let report_time_j_value = JValue::from(alert.report.report_time.value as i64);
 
@@ -623,8 +623,8 @@ pub fn alert_to_jobject(alert: Alert, env: &JNIEnv) -> Result<jobject, ServicesE
     let other_j_value = JValue::from(alert.report.other);
     let no_symptoms_j_value = JValue::from(alert.report.no_symptoms);
 
-    let jni_public_report_obj = env.new_object(
-        jni_public_report_class,
+    let jni_public_symptoms_obj = env.new_object(
+        jni_public_symptoms_class,
         "(JJIIZZZZZZZ)V",
         &[
             report_time_j_value,
@@ -654,10 +654,10 @@ pub fn alert_to_jobject(alert: Alert, env: &JNIEnv) -> Result<jobject, ServicesE
     let result: Result<jobject, jni::errors::Error> = env
         .new_object(
             jni_alert_class,
-            "(Ljava/lang/String;Lorg/coepi/core/jni/JniPublicReport;JJFF)V",
+            "(Ljava/lang/String;Lorg/coepi/core/jni/JniPublicSymptoms;JJFF)V",
             &[
                 id_j_value,
-                JValue::from(jni_public_report_obj),
+                JValue::from(jni_public_symptoms_obj),
                 contact_start_j_value,
                 contact_end_j_value,
                 min_distance_j_value,

--- a/src/android/android_interface.rs
+++ b/src/android/android_interface.rs
@@ -565,7 +565,7 @@ fn register_callback_internal(callback: Box<dyn LogCallbackWrapper>) {
 
 // To prefill the JNI array (TODO can this be skipped?)
 fn placeholder_alert() -> Alert {
-    let report = PublicSymptoms {
+    let symptoms = PublicSymptoms {
         report_time: UnixTime { value: 0 },
         earliest_symptom_time: UserInput::Some(UnixTime { value: 0 }),
         fever_severity: FeverSeverity::None,
@@ -581,7 +581,8 @@ fn placeholder_alert() -> Alert {
 
     Alert {
         id: "0".to_owned(),
-        report,
+        report_id: "0".to_owned(),
+        symptoms,
         contact_start: 0,
         contact_end: 0,
         min_distance: 0.0,
@@ -592,22 +593,22 @@ fn placeholder_alert() -> Alert {
 pub fn alert_to_jobject(alert: Alert, env: &JNIEnv) -> Result<jobject, ServicesError> {
     let jni_public_symptoms_class = env.find_class("org/coepi/core/jni/JniPublicSymptoms")?;
 
-    let report_time_j_value = JValue::from(alert.report.report_time.value as i64);
+    let report_time_j_value = JValue::from(alert.symptoms.report_time.value as i64);
 
-    let earliest_time = match &alert.report.earliest_symptom_time {
+    let earliest_time = match &alert.symptoms.earliest_symptom_time {
         UserInput::Some(time) => time.value as i64,
         UserInput::None => -1,
     };
     let earliest_time_j_value = JValue::from(earliest_time);
 
-    let fever_severity = match &alert.report.fever_severity {
+    let fever_severity = match &alert.symptoms.fever_severity {
         FeverSeverity::None => 0,
         FeverSeverity::Mild => 1,
         FeverSeverity::Serious => 2,
     };
     let fever_severity_j_value = JValue::from(fever_severity);
 
-    let cough_severity = match &alert.report.cough_severity {
+    let cough_severity = match &alert.symptoms.cough_severity {
         CoughSeverity::None => 0,
         CoughSeverity::Existing => 1,
         CoughSeverity::Wet => 2,
@@ -615,13 +616,13 @@ pub fn alert_to_jobject(alert: Alert, env: &JNIEnv) -> Result<jobject, ServicesE
     };
     let cough_severity_j_value = JValue::from(cough_severity);
 
-    let breathlessness_j_value = JValue::from(alert.report.breathlessness);
-    let muscle_aches_j_value = JValue::from(alert.report.muscle_aches);
-    let loss_smell_or_taste_j_value = JValue::from(alert.report.loss_smell_or_taste);
-    let diarrhea_j_value = JValue::from(alert.report.diarrhea);
-    let runny_nose_j_value = JValue::from(alert.report.runny_nose);
-    let other_j_value = JValue::from(alert.report.other);
-    let no_symptoms_j_value = JValue::from(alert.report.no_symptoms);
+    let breathlessness_j_value = JValue::from(alert.symptoms.breathlessness);
+    let muscle_aches_j_value = JValue::from(alert.symptoms.muscle_aches);
+    let loss_smell_or_taste_j_value = JValue::from(alert.symptoms.loss_smell_or_taste);
+    let diarrhea_j_value = JValue::from(alert.symptoms.diarrhea);
+    let runny_nose_j_value = JValue::from(alert.symptoms.runny_nose);
+    let other_j_value = JValue::from(alert.symptoms.other);
+    let no_symptoms_j_value = JValue::from(alert.symptoms.no_symptoms);
 
     let jni_public_symptoms_obj = env.new_object(
         jni_public_symptoms_class,

--- a/src/android/jni_domain_tests.rs
+++ b/src/android/jni_domain_tests.rs
@@ -2,7 +2,7 @@ use super::android_interface::{alert_to_jobject, jni_obj_result};
 use crate::{
     expect_log,
     reporting::{
-        public_report::{CoughSeverity, FeverSeverity, PublicReport},
+        public_report::{CoughSeverity, FeverSeverity, PublicSymptoms},
         symptom_inputs::UserInput,
     },
     reports_interval::UnixTime,
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn Java_org_coepi_core_jni_JniApi_testReturnMultipleAlerts
 }
 
 fn create_test_alert(id: &str, report_time: u64) -> Alert {
-    let report = PublicReport {
+    let report = PublicSymptoms {
         report_time: UnixTime { value: report_time },
         earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
         fever_severity: FeverSeverity::Mild,

--- a/src/android/jni_domain_tests.rs
+++ b/src/android/jni_domain_tests.rs
@@ -2,7 +2,7 @@ use super::android_interface::{alert_to_jobject, jni_obj_result};
 use crate::{
     expect_log,
     reporting::{
-        public_report::{CoughSeverity, FeverSeverity, PublicSymptoms},
+        public_symptoms::{CoughSeverity, FeverSeverity, PublicSymptoms},
         symptom_inputs::UserInput,
     },
     reports_interval::UnixTime,
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn Java_org_coepi_core_jni_JniApi_testReturnMultipleAlerts
 }
 
 fn create_test_alert(id: &str, report_time: u64) -> Alert {
-    let report = PublicSymptoms {
+    let symptoms = PublicSymptoms {
         report_time: UnixTime { value: report_time },
         earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
         fever_severity: FeverSeverity::Mild,
@@ -80,7 +80,8 @@ fn create_test_alert(id: &str, report_time: u64) -> Alert {
 
     Alert {
         id: id.to_owned(),
-        report,
+        report_id: id.to_owned(), // re-use alert id, not particular reason other than we don't need separate id for now
+        symptoms,
         contact_start: 1592567315,
         contact_end: 1592567335,
         min_distance: 1.2,

--- a/src/database/alert_dao.rs
+++ b/src/database/alert_dao.rs
@@ -51,6 +51,7 @@ impl AlertDaoImpl {
                 runny_nose integer not null,
                 other integer not null,
                 no_symptoms integer not null,
+                report_id text not null,
                 deleted integer
             )",
             params![],
@@ -60,7 +61,7 @@ impl AlertDaoImpl {
 
     fn to_alert(row: &Row) -> Alert {
         let id_res = row.get(0);
-        let id: String = expect_log!(id_res, "Invalid row: no id");
+        let id = expect_log!(id_res, "Invalid row: no id");
 
         let start_res = row.get(1);
         let start: i64 = expect_log!(start_res, "Invalid row: no start");
@@ -122,8 +123,12 @@ impl AlertDaoImpl {
         let no_symptoms_res = row.get(15);
         let no_symptoms: i8 = expect_log!(no_symptoms_res, "Invalid row: no no_symptoms");
 
+        let report_id_res = row.get(16);
+        let report_id = expect_log!(report_id_res, "Invalid row: no report_id");
+
         Alert {
             id,
+            report_id,
             report: PublicReport {
                 report_time: UnixTime {
                     value: report_time as u64,
@@ -167,7 +172,8 @@ impl AlertDao for AlertDaoImpl {
                 diarrhea,
                 runny_nose,
                 other,
-                no_symptoms 
+                no_symptoms,
+                report_id
                 from alert where deleted is null",
                 NO_PARAMS,
                 |row| Self::to_alert(row),
@@ -207,7 +213,7 @@ impl AlertDao for AlertDaoImpl {
                         id,
                         start,
                         end,
-                        min_distance ,
+                        min_distance,
                         avg_distance,
                         report_time,
                         earliest_symptom_time,
@@ -219,8 +225,9 @@ impl AlertDao for AlertDaoImpl {
                         diarrhea,
                         runny_nose,
                         other,
-                        no_symptoms
-                    ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                        no_symptoms,
+                        report_id
+                    ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                     params![
                         alert.id,
                         alert.contact_start as i64,
@@ -241,7 +248,8 @@ impl AlertDao for AlertDaoImpl {
                         to_db_int(alert.report.diarrhea),
                         to_db_int(alert.report.runny_nose),
                         to_db_int(alert.report.other),
-                        to_db_int(alert.report.no_symptoms)
+                        to_db_int(alert.report.no_symptoms),
+                        alert.report_id
                     ],
                 )?;
             }
@@ -301,6 +309,7 @@ mod tests {
 
         let alert = Alert {
             id: "1".to_owned(),
+            report_id: "1".to_owned(),
             report,
             contact_start: 1000,
             contact_end: 2000,
@@ -343,6 +352,7 @@ mod tests {
 
         let alert1 = Alert {
             id: "1".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1000,
             contact_end: 2000,
@@ -352,6 +362,7 @@ mod tests {
 
         let alert2 = Alert {
             id: "1".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1001,
             contact_end: 2001,
@@ -394,6 +405,7 @@ mod tests {
 
         let alert1 = Alert {
             id: "1".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1000,
             contact_end: 2000,
@@ -403,6 +415,7 @@ mod tests {
 
         let alert2 = Alert {
             id: "2".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1001,
             contact_end: 2001,
@@ -446,6 +459,7 @@ mod tests {
 
         let alert1 = Alert {
             id: "1".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1000,
             contact_end: 2000,
@@ -455,6 +469,7 @@ mod tests {
 
         let alert2 = Alert {
             id: "2".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1001,
             contact_end: 2001,
@@ -500,6 +515,7 @@ mod tests {
 
         let alert1 = Alert {
             id: "1".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1000,
             contact_end: 2000,
@@ -509,6 +525,7 @@ mod tests {
 
         let alert2 = Alert {
             id: "2".to_owned(),
+            report_id: "1".to_owned(),
             report: report.clone(),
             contact_start: 1001,
             contact_end: 2001,

--- a/src/database/alert_dao.rs
+++ b/src/database/alert_dao.rs
@@ -3,7 +3,7 @@ use crate::{
     errors::ServicesError,
     expect_log,
     reporting::{
-        public_report::{CoughSeverity, FeverSeverity, PublicReport},
+        public_symptoms::{CoughSeverity, FeverSeverity, PublicSymptoms},
         symptom_inputs::UserInput,
     },
     reports_interval,
@@ -129,7 +129,7 @@ impl AlertDaoImpl {
         Alert {
             id,
             report_id,
-            report: PublicReport {
+            symptoms: PublicSymptoms {
                 report_time: UnixTime {
                     value: report_time as u64,
                 },
@@ -234,21 +234,21 @@ impl AlertDao for AlertDaoImpl {
                         alert.contact_end as i64,
                         alert.min_distance as f64,
                         alert.avg_distance as f64,
-                        alert.report.report_time.value as i64,
+                        alert.symptoms.report_time.value as i64,
                         alert
-                            .report
+                            .symptoms
                             .earliest_symptom_time
                             .as_opt()
                             .map(|unix_time| unix_time.value as i64),
-                        alert.report.fever_severity.raw_value() as i64,
-                        alert.report.cough_severity.raw_value() as i64,
-                        to_db_int(alert.report.breathlessness),
-                        to_db_int(alert.report.muscle_aches),
-                        to_db_int(alert.report.loss_smell_or_taste),
-                        to_db_int(alert.report.diarrhea),
-                        to_db_int(alert.report.runny_nose),
-                        to_db_int(alert.report.other),
-                        to_db_int(alert.report.no_symptoms),
+                        alert.symptoms.fever_severity.raw_value() as i64,
+                        alert.symptoms.cough_severity.raw_value() as i64,
+                        to_db_int(alert.symptoms.breathlessness),
+                        to_db_int(alert.symptoms.muscle_aches),
+                        to_db_int(alert.symptoms.loss_smell_or_taste),
+                        to_db_int(alert.symptoms.diarrhea),
+                        to_db_int(alert.symptoms.runny_nose),
+                        to_db_int(alert.symptoms.other),
+                        to_db_int(alert.symptoms.no_symptoms),
                         alert.report_id
                     ],
                 )?;
@@ -293,7 +293,7 @@ mod tests {
         ));
         let alert_dao = AlertDaoImpl::new(database.clone());
 
-        let report = PublicReport {
+        let symptoms = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
             fever_severity: FeverSeverity::Mild,
@@ -310,7 +310,7 @@ mod tests {
         let alert = Alert {
             id: "1".to_owned(),
             report_id: "1".to_owned(),
-            report,
+            symptoms,
             contact_start: 1000,
             contact_end: 2000,
             min_distance: 2.3,
@@ -336,7 +336,7 @@ mod tests {
         ));
         let alert_dao = AlertDaoImpl::new(database.clone());
 
-        let report = PublicReport {
+        let symptoms = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
             fever_severity: FeverSeverity::Mild,
@@ -353,7 +353,7 @@ mod tests {
         let alert1 = Alert {
             id: "1".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1000,
             contact_end: 2000,
             min_distance: 2.3,
@@ -363,7 +363,7 @@ mod tests {
         let alert2 = Alert {
             id: "1".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1001,
             contact_end: 2001,
             min_distance: 2.4,
@@ -389,7 +389,7 @@ mod tests {
         ));
         let alert_dao = AlertDaoImpl::new(database.clone());
 
-        let report = PublicReport {
+        let symptoms = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
             fever_severity: FeverSeverity::Mild,
@@ -406,7 +406,7 @@ mod tests {
         let alert1 = Alert {
             id: "1".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1000,
             contact_end: 2000,
             min_distance: 2.3,
@@ -416,7 +416,7 @@ mod tests {
         let alert2 = Alert {
             id: "2".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1001,
             contact_end: 2001,
             min_distance: 2.4,
@@ -443,7 +443,7 @@ mod tests {
         ));
         let alert_dao = AlertDaoImpl::new(database.clone());
 
-        let report = PublicReport {
+        let symptoms = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
             fever_severity: FeverSeverity::Mild,
@@ -460,7 +460,7 @@ mod tests {
         let alert1 = Alert {
             id: "1".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1000,
             contact_end: 2000,
             min_distance: 2.3,
@@ -470,7 +470,7 @@ mod tests {
         let alert2 = Alert {
             id: "2".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1001,
             contact_end: 2001,
             min_distance: 2.4,
@@ -499,7 +499,7 @@ mod tests {
         ));
         let alert_dao = AlertDaoImpl::new(database.clone());
 
-        let report = PublicReport {
+        let symptoms = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
             fever_severity: FeverSeverity::Mild,
@@ -516,7 +516,7 @@ mod tests {
         let alert1 = Alert {
             id: "1".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1000,
             contact_end: 2000,
             min_distance: 2.3,
@@ -526,7 +526,7 @@ mod tests {
         let alert2 = Alert {
             id: "2".to_owned(),
             report_id: "1".to_owned(),
-            report: report.clone(),
+            symptoms: symptoms.clone(),
             contact_start: 1001,
             contact_end: 2001,
             min_distance: 2.4,

--- a/src/reporting/mappers.rs
+++ b/src/reporting/mappers.rs
@@ -1,6 +1,6 @@
 use super::{
     bit_vector::BitVector,
-    public_report::{CoughSeverity, FeverSeverity},
+    public_symptoms::{CoughSeverity, FeverSeverity},
     symptom_inputs::UserInput,
 };
 use crate::{expect_log, reports_interval::UnixTime};

--- a/src/reporting/memo.rs
+++ b/src/reporting/memo.rs
@@ -4,7 +4,7 @@ use super::{
         BitMapper, BitVectorMappable, BoolMapper, CoughSeverityMapper, FeverSeverityMapper,
         TimeMapper, TimeUserInputMapper, VersionMapper,
     },
-    public_report::PublicReport,
+    public_symptoms::PublicSymptoms,
 };
 use crate::expect_log;
 #[cfg(target_os = "android")]
@@ -15,8 +15,8 @@ pub struct Memo {
     pub bytes: Vec<u8>,
 }
 pub trait MemoMapper {
-    fn to_memo(&self, report: PublicReport) -> Memo;
-    fn to_report(&self, memo: Memo) -> PublicReport;
+    fn to_memo(&self, report: PublicSymptoms) -> Memo;
+    fn to_report(&self, memo: Memo) -> PublicSymptoms;
 }
 
 pub struct MemoMapperImpl {}
@@ -31,7 +31,7 @@ impl MemoMapperImpl {
 }
 
 impl MemoMapper for MemoMapperImpl {
-    fn to_memo(&self, report: PublicReport) -> Memo {
+    fn to_memo(&self, report: PublicSymptoms) -> Memo {
         let memo_version: u16 = 1;
 
         let bits = vec![
@@ -57,7 +57,7 @@ impl MemoMapper for MemoMapperImpl {
         }
     }
 
-    fn to_report(&self, memo: Memo) -> PublicReport {
+    fn to_report(&self, memo: Memo) -> PublicSymptoms {
         let bits: Vec<bool> = memo
             .bytes
             .into_iter()
@@ -85,7 +85,7 @@ impl MemoMapper for MemoMapperImpl {
         let other = extract(&bits, &Self::BOOLEAN_MAPPER, next).value(|v| next += v);
         let no_symptoms = extract(&bits, &Self::BOOLEAN_MAPPER, next).value(|v| next += v);
 
-        PublicReport {
+        PublicSymptoms {
             report_time,
             earliest_symptom_time,
             fever_severity,
@@ -128,7 +128,7 @@ fn extract<T>(bits: &Vec<bool>, mapper: &dyn BitMapper<T>, start: usize) -> Extr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reporting::public_report::{CoughSeverity, FeverSeverity};
+    use crate::reporting::public_symptoms::{CoughSeverity, FeverSeverity};
     use crate::reporting::symptom_inputs::UserInput;
     use crate::reports_interval::UnixTime;
 
@@ -136,7 +136,7 @@ mod tests {
     fn maps_nothing_set() {
         let memo_mapper = MemoMapperImpl {};
 
-        let report = PublicReport {
+        let report = PublicSymptoms {
             report_time: UnixTime { value: 1589209754 },
             earliest_symptom_time: UserInput::None,
             fever_severity: FeverSeverity::None,
@@ -151,7 +151,7 @@ mod tests {
         };
 
         let memo: Memo = memo_mapper.to_memo(report.clone());
-        let mapped_report: PublicReport = memo_mapper.to_report(memo);
+        let mapped_report: PublicSymptoms = memo_mapper.to_report(memo);
 
         assert_eq!(mapped_report, report.clone());
     }
@@ -160,7 +160,7 @@ mod tests {
     fn maps_all_symptoms_set_arbitrary() {
         let memo_mapper = MemoMapperImpl {};
 
-        let report = PublicReport {
+        let report = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1589209754 }),
             fever_severity: FeverSeverity::Serious,
@@ -175,7 +175,7 @@ mod tests {
         };
 
         let memo: Memo = memo_mapper.to_memo(report.clone());
-        let mapped_report: PublicReport = memo_mapper.to_report(memo);
+        let mapped_report: PublicSymptoms = memo_mapper.to_report(memo);
 
         assert_eq!(mapped_report, report.clone());
     }

--- a/src/reporting/mod.rs
+++ b/src/reporting/mod.rs
@@ -1,6 +1,6 @@
 pub mod bit_vector;
 pub mod mappers;
 pub mod memo;
-pub mod public_report;
+pub mod public_symptoms;
 pub mod symptom_inputs;
 pub mod symptom_inputs_manager;

--- a/src/reporting/public_symptoms.rs
+++ b/src/reporting/public_symptoms.rs
@@ -65,7 +65,7 @@ impl CoughSeverity {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Eq)]
-pub struct PublicReport {
+pub struct PublicSymptoms {
     pub report_time: UnixTime,
     pub earliest_symptom_time: UserInput<UnixTime>,
     pub fever_severity: FeverSeverity,
@@ -79,8 +79,8 @@ pub struct PublicReport {
     pub no_symptoms: bool, // https://github.com/Co-Epi/app-ios/issues/268#issuecomment-645583717
 }
 
-impl PublicReport {
-    pub fn with_inputs(inputs: SymptomInputs, report_time: UnixTime) -> Option<PublicReport> {
+impl PublicSymptoms {
+    pub fn with_inputs(inputs: SymptomInputs, report_time: UnixTime) -> Option<PublicSymptoms> {
         let earliest_symptom_time = inputs.earliest_symptom.time.clone();
         let fever_severity = to_fever_severity(&inputs.fever);
         let cough_severity =
@@ -103,7 +103,7 @@ impl PublicReport {
             || other
             || no_symptoms
         {
-            Some(PublicReport {
+            Some(PublicSymptoms {
                 report_time,
                 earliest_symptom_time,
                 fever_severity,

--- a/src/reporting/symptom_inputs.rs
+++ b/src/reporting/symptom_inputs.rs
@@ -1,4 +1,4 @@
-use super::{memo::MemoMapper, public_report::*};
+use super::{memo::MemoMapper, public_symptoms::*};
 use crate::{
     errors::ServicesError, expect_log, networking::TcnApi, reports_interval::UnixTime,
     tcn_ext::tcn_keys::TcnKeys,
@@ -170,7 +170,7 @@ impl<'a, T: MemoMapper, U: TcnKeys, V: TcnApi> SymptomInputsSubmitter<T, U, V>
     for SymptomInputsSubmitterImpl<'a, T, U, V>
 {
     fn submit_inputs(&self, inputs: SymptomInputs) -> Result<(), ServicesError> {
-        if let Some(report) = PublicReport::with_inputs(inputs, UnixTime::now()) {
+        if let Some(report) = PublicSymptoms::with_inputs(inputs, UnixTime::now()) {
             self.send_report(report)
         } else {
             debug!("Nothing to send.");
@@ -180,7 +180,7 @@ impl<'a, T: MemoMapper, U: TcnKeys, V: TcnApi> SymptomInputsSubmitter<T, U, V>
 }
 
 impl<'a, T: MemoMapper, U: TcnKeys, V: TcnApi> SymptomInputsSubmitterImpl<'a, T, U, V> {
-    fn send_report(&self, report: PublicReport) -> Result<(), ServicesError> {
+    fn send_report(&self, report: PublicSymptoms) -> Result<(), ServicesError> {
         debug!("Will send public report: {:?}", report);
 
         let memo = self.memo_mapper.to_memo(report);
@@ -220,7 +220,7 @@ mod tests {
     use tcn::{ReportAuthorizationKey, TemporaryContactKey};
 
     #[test]
-    fn test_public_report_with_inputs() {
+    fn test_public_symptoms_with_inputs() {
         simple_logger::setup();
 
         let breathlessness = Breathlessness {
@@ -259,13 +259,13 @@ mod tests {
             earliest_symptom,
         };
 
-        let public_report = PublicReport::with_inputs(inputs, UnixTime { value: 0 }).unwrap();
+        let public_symptoms = PublicSymptoms::with_inputs(inputs, UnixTime { value: 0 }).unwrap();
 
-        debug!("{:?}", public_report);
+        debug!("{:?}", public_symptoms);
 
-        info!(target: "test_events", "Logging PublicReport: {:?}", public_report);
+        info!(target: "test_events", "Logging PublicSymptoms: {:?}", public_symptoms);
         /*
-          PublicReport {
+          PublicSymptoms {
             earliest_symptom_time: Some(
                 UnixTime {
                     value: 1590356601,
@@ -277,14 +277,14 @@ mod tests {
         }
           */
 
-        assert_eq!(CoughSeverity::Dry, public_report.cough_severity);
-        assert_eq!(FeverSeverity::Mild, public_report.fever_severity);
-        assert_eq!(true, public_report.breathlessness);
+        assert_eq!(CoughSeverity::Dry, public_symptoms.cough_severity);
+        assert_eq!(FeverSeverity::Mild, public_symptoms.fever_severity);
+        assert_eq!(true, public_symptoms.breathlessness);
     }
 
     #[test]
-    fn test_public_report_to_signed_report() {
-        let report_which_should_be_sent = PublicReport {
+    fn test_public_symptoms_to_signed_report() {
+        let report_which_should_be_sent = PublicSymptoms {
             report_time: UnixTime { value: 0 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1590356601 }),
             fever_severity: FeverSeverity::Mild,

--- a/src/reports_update/reports_updater.rs
+++ b/src/reports_update/reports_updater.rs
@@ -25,6 +25,8 @@ struct Element {}
 #[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct Alert {
     pub id: String,
+    pub report_id: String,
+
     pub report: PublicReport,
 
     // Note: for now these fields "raw", as this struct is used for FFI.
@@ -127,6 +129,7 @@ where
 
         Ok(Alert {
             id: format!("{:?}", signed_report.sig), // TODO this is wrong now: one report can have multiple alerts
+            report_id: format!("{:?}", signed_report.sig),
             report: public_report,
             contact_start: measurements.contact_start.value,
             contact_end: measurements.contact_end.value,

--- a/src/reports_update/reports_updater.rs
+++ b/src/reports_update/reports_updater.rs
@@ -9,7 +9,7 @@ use crate::{
     networking::{NetworkingError, TcnApi},
     reporting::{
         memo::{Memo, MemoMapper},
-        public_report::PublicReport,
+        public_symptoms::PublicSymptoms,
     },
     reports_interval, signed_report_to_bytes,
 };
@@ -27,7 +27,7 @@ pub struct Alert {
     pub id: String,
     pub report_id: String,
 
-    pub report: PublicReport,
+    pub symptoms: PublicSymptoms,
 
     // Note: for now these fields "raw", as this struct is used for FFI.
     // if it's needed to manipulate Alert in Rust, a separate type should be created.
@@ -121,7 +121,7 @@ where
     ) -> Result<Alert, ServicesError> {
         let report = signed_report.clone().verify()?;
 
-        let public_report = self.memo_mapper.to_report(Memo {
+        let public_symptoms = self.memo_mapper.to_report(Memo {
             bytes: report.memo_data().to_vec(),
         });
 
@@ -130,7 +130,7 @@ where
         Ok(Alert {
             id: format!("{:?}", signed_report.sig), // TODO this is wrong now: one report can have multiple alerts
             report_id: format!("{:?}", signed_report.sig),
-            report: public_report,
+            symptoms: public_symptoms,
             contact_start: measurements.contact_start.value,
             contact_end: measurements.contact_end.value,
             min_distance: measurements.min_distance,

--- a/src/reports_update/tcn_matcher.rs
+++ b/src/reports_update/tcn_matcher.rs
@@ -90,7 +90,7 @@ mod tests {
     use crate::{
         reporting::{
             memo::{MemoMapper, MemoMapperImpl},
-            public_report::{CoughSeverity, FeverSeverity, PublicReport},
+            public_symptoms::{CoughSeverity, FeverSeverity, PublicSymptoms},
             symptom_inputs::UserInput,
         },
         reports_interval::UnixTime,
@@ -223,7 +223,7 @@ mod tests {
 
     fn create_test_report() -> SignedReport {
         let memo_mapper = MemoMapperImpl {};
-        let public_report = PublicReport {
+        let public_symptoms = PublicSymptoms {
             report_time: UnixTime { value: 1589209754 },
             earliest_symptom_time: UserInput::Some(UnixTime { value: 1589209754 }),
             fever_severity: FeverSeverity::Serious,
@@ -237,7 +237,7 @@ mod tests {
             no_symptoms: true,
         };
         let rak = ReportAuthorizationKey::new(rand::thread_rng());
-        let memo_data = memo_mapper.to_memo(public_report);
+        let memo_data = memo_mapper.to_memo(public_symptoms);
         rak.create_report(MemoType::CoEpiV1, memo_data.bytes, 1, 10000)
             .unwrap()
     }


### PR DESCRIPTION
- Added report id as `Alert` field, to be able to link them (will do this likely in the apps).
- Renamed `PublicReport` in `PublicSymptoms`, to differentiate it better from the actual report. Otherwise it'd have seemed correct to add `report_id` to `PublicReport`, but this can't be done, since we don't have a report signature yet when creating it.