### PR TITLE
Add start time to alerts unique

### DIFF
--- a/src/reports_update/reports_updater.rs
+++ b/src/reports_update/reports_updater.rs
@@ -126,11 +126,13 @@ where
         });
 
         let measurements = exposure.measurements();
+        let report_sig_bytes: [u8; 64] = signed_report.sig.into();
 
         Ok(Alert {
             id: format!(
-                "{:?}#{}",
-                signed_report.sig, measurements.contact_start.value
+                "{}-{}",
+                hex::encode(report_sig_bytes.to_vec()),
+                measurements.contact_start.value
             ),
             report_id: format!("{:?}", signed_report.sig),
             symptoms: public_symptoms,

--- a/src/reports_update/reports_updater.rs
+++ b/src/reports_update/reports_updater.rs
@@ -128,7 +128,10 @@ where
         let measurements = exposure.measurements();
 
         Ok(Alert {
-            id: format!("{:?}", signed_report.sig), // TODO this is wrong now: one report can have multiple alerts
+            id: format!(
+                "{:?}#{}",
+                signed_report.sig, measurements.contact_start.value
+            ),
             report_id: format!("{:?}", signed_report.sig),
             symptoms: public_symptoms,
             contact_start: measurements.contact_start.value,


### PR DESCRIPTION
The report signature now uses hex instead of the previous debug representation of the byte array.